### PR TITLE
Remove Directional Parameters

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GaussianMixtureAlignment"
 uuid = "f2431ed1-b9c2-4fdb-af1b-a74d6c93b3b3"
 authors = ["Tom McGrath <tmcgrath325@gmail.com> and contributors"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"

--- a/src/gogma/bounds.jl
+++ b/src/gogma/bounds.jl
@@ -43,27 +43,8 @@ See [Campbell & Peterson, 2016](https://arxiv.org/abs/1603.00150)
 function gauss_l2_bounds(x::AbstractIsotropicGaussian, y::AbstractIsotropicGaussian, R::RotationVec, T::SVector{3}, σᵣ, σₜ, s=x.σ^2 + y.σ^2, w=x.ϕ*y.ϕ; distance_bound_fun = tight_distance_bounds)
     (lbdist, ubdist) = distance_bound_fun(R*x.μ, y.μ-T, σᵣ, σₜ)
 
-    if length(x.dirs) == 0 || length(y.dirs) == 0
-        lbdot = 1.
-        cosγ = 1.
-    else
-        cosβ = cos(min(sqrt3*σᵣ, π))
-        cosγ = -1.
-        for xdir in x.dirs
-            for ydir in y.dirs
-                cosγ = max(cosγ, dot(xdir, ydir))
-            end
-        end
-        if cosγ >= cosβ
-            lbdot = 1.
-        else
-            lbdot = cosγ*cosβ + √(1-cosγ^2)*√(1-cosβ^2)
-            # lbdot = cosγ*cosβ + √(1 - cosγ^2 - cosβ^2 + cosγ^2*cosβ^2)
-        end
-    end
-
     # evaluate objective function at each distance to get upper and lower bounds
-    return -overlap(lbdist^2, s, w, lbdot), -overlap(ubdist^2, s, w, cosγ)
+    return -overlap(lbdist^2, s, w), -overlap(ubdist^2, s, w)
 end
 
 # gauss_l2_bounds(x::AbstractGaussian, y::AbstractGaussian, R::RotationVec, T::SVector{3}, σᵣ, σₜ, s=x.σ^2 + y.σ^2, w=x.ϕ*y.ϕ; kwargs...

--- a/src/gogma/gmm.jl
+++ b/src/gogma/gmm.jl
@@ -58,25 +58,22 @@ eltype(mgmm::AbstractMultiGMM) = eltype(mgmm.gmms);
 A structure that defines an isotropic Gaussian distribution with the location of the mean, `μ`, standard deviation `σ`, 
 and scaling factor `ϕ`. 
 
-An `IsotropicGaussian` can also be assigned directions `dirs` which enforce a penalty for misalignment with the `dirs` of 
-another `IsotropicGaussian`.
 """
 struct IsotropicGaussian{N,T} <: AbstractIsotropicGaussian{N,T}
     μ::SVector{N,T}
     σ::T
     ϕ::T
-    dirs::Vector{SVector{N,T}}
 end
-IsotropicGaussian(μ::SVector{N,T},σ::T,ϕ::T,dirs::Vector{SVector{N,T}}) where {N,T<:Real} = IsotropicGaussian{N,T}(μ,σ,ϕ,dirs)
+IsotropicGaussian(μ::SVector{N,T},σ::T,ϕ::T) where {N,T<:Real} = IsotropicGaussian{N,T}(μ,σ,ϕ)
 
-function IsotropicGaussian(μ::AbstractArray, σ::Real, ϕ::Real, dirs::AbstractArray=SVector{length(μ),eltype(μ)}[])
-    t = promote_type(eltype(μ), typeof(σ), typeof(ϕ), eltype(eltype(dirs)))
-    return IsotropicGaussian{length(μ),t}(SVector{length(μ),t}(μ), t(σ), t(ϕ), SVector{length(μ),t}[SVector{length(μ),t}(dir/norm(dir)) for dir in dirs])
+function IsotropicGaussian(μ::AbstractArray, σ::Real, ϕ::Real)
+    t = promote_type(eltype(μ), typeof(σ), typeof(ϕ))
+    return IsotropicGaussian{length(μ),t}(SVector{length(μ),t}(μ), t(σ), t(ϕ))
 end
 
-IsotropicGaussian(g::AbstractIsotropicGaussian) = IsotropicGaussian(g.μ, g.σ, g.ϕ, g.dirs)
+IsotropicGaussian(g::AbstractIsotropicGaussian) = IsotropicGaussian(g.μ, g.σ, g.ϕ)
 
-convert(::Type{IsotropicGaussian{N,T}}, g::AbstractIsotropicGaussian) where {N,T} = IsotropicGaussian(SVector{N,T}(g.μ), T(g.σ), T(g.ϕ), Vector{SVector{N,T}}(g.dirs))
+convert(::Type{IsotropicGaussian{N,T}}, g::AbstractIsotropicGaussian) where {N,T} = IsotropicGaussian(SVector{N,T}(g.μ), T(g.σ), T(g.ϕ))
 promote_rule(::Type{IsotropicGaussian{N,T}}, ::Type{IsotropicGaussian{N,S}}) where {N,T<:Real,S<:Real} = IsotropicGaussian{N,promote_type(T,S)} 
 
 
@@ -113,8 +110,7 @@ weights(gmm::AbstractSingleGMM) = [g.ϕ for g in gmm.gaussians]
 
 Base.show(io::IO, g::AbstractIsotropicGaussian) = println(io,
     summary(g),
-    " with mean $(g.μ), standard deviation $(g.σ), amplitude $(g.ϕ),\n",
-    " and $(length(g.dirs)) directional constraints."
+    " with mean $(g.μ), standard deviation $(g.σ), and amplitude $(g.ϕ).\n"
 )
 
 Base.show(io::IO, gmm::AbstractIsotropicGMM) = println(io,

--- a/src/gogma/overlap.jl
+++ b/src/gogma/overlap.jl
@@ -1,24 +1,23 @@
 """
-    ovlp = overlap(distsq, s, w, dirdot)
+    ovlp = overlap(distsq, s, w)
 
 Calculates the unnormalized overlap between two Gaussian distributions with width `s`, 
-weight `w', and squared distance `distsq`, and geometric scaling factor `dirdot`.
+weight `w', and squared distance `distsq`.
 """
-function overlap(distsq::Real, s::Real, w::Real, dirdot::Real)
-    return w * 0.5*(1+dirdot) * exp(-distsq / (2*s)) # / (sqrt2pi * sqrt(s))^ndims
+function overlap(distsq::Real, s::Real, w::Real)
+    return w * exp(-distsq / (2*s)) # / (sqrt2pi * sqrt(s))^ndims
     # Note, the normalization term for the Gaussians is left out, since it is not required that the total "volume" of each Gaussian
     # is equal to 1 (e.g. satisfying the requirements for a probability distribution)
 end
 
 """
-    ovlp = overlap(dist, σx, σy, ϕx, ϕy, dirdot)
+    ovlp = overlap(dist, σx, σy, ϕx, ϕy)
 
 Calculates the unnormalized overlap between two Gaussian distributions with variances
-`σx` and `σy`, weights `ϕx` and `ϕy`, and means separated by distance `dist`, scaled
-by the dot product obtained from geometric constraints `dirdot`.
+`σx` and `σy`, weights `ϕx` and `ϕy`, and means separated by distance `dist`.
 """
-function overlap(dist::Real, σx::Real, σy::Real, ϕx::Real, ϕy::Real, dirdot::Real) 
-    return overlap(dist^2, σx^2 + σy^2, ϕx*ϕy, dirdot)
+function overlap(dist::Real, σx::Real, σy::Real, ϕx::Real, ϕy::Real) 
+    return overlap(dist^2, σx^2 + σy^2, ϕx*ϕy)
 end
 
 """
@@ -33,17 +32,7 @@ function overlap(x::AbstractIsotropicGaussian, y::AbstractIsotropicGaussian, s=n
     if isnothing(w)
         w = x.ϕ*y.ϕ
     end
-    if length(x.dirs) == 0 || length(y.dirs) == 0
-        cosγ = 1.
-    else
-        cosγ = -1
-        for xdir in x.dirs
-            for ydir in y.dirs
-                cosγ = max(cosγ, dot(xdir, ydir))
-            end
-        end
-    end
-    return overlap(sum(abs2, x.μ.-y.μ), s, w, cosγ) 
+    return overlap(sum(abs2, x.μ.-y.μ), s, w) 
 end
 
 """

--- a/src/gogma/tiv.jl
+++ b/src/gogma/tiv.jl
@@ -27,7 +27,7 @@ function tivgmm(gmm::AbstractIsotropicGMM, c=Inf)
         i = Int(floor((idx-1)/npts)+1)
         j = mod(idx-1, npts)+1
         x, y = gmm.gaussians[i], gmm.gaussians[j]
-        push!(tivgaussians, IsotropicGaussian(x.μ-y.μ, √(x.σ*y.σ), √(x.ϕ*y.ϕ), x.dirs))
+        push!(tivgaussians, IsotropicGaussian(x.μ-y.μ, √(x.σ*y.σ), √(x.ϕ*y.ϕ)))
     end
     return IsotropicGMM(tivgaussians)
 end

--- a/src/gogma/transformation.jl
+++ b/src/gogma/transformation.jl
@@ -1,11 +1,11 @@
 function Base.:*(R::AbstractMatrix{W}, x::IsotropicGaussian{N,V}) where {N,V,W}
     numtype = promote_type(V, W)
-    return IsotropicGaussian{N,numtype}(R*x.μ, x.σ, x.ϕ, [R*dir for dir in x.dirs])
+    return IsotropicGaussian{N,numtype}(R*x.μ, x.σ, x.ϕ)
 end
 
 function Base.:+(x::IsotropicGaussian{N,V}, T::AbstractVector{W}) where {N,V,W}
     numtype = promote_type(V, W)
-    return IsotropicGaussian{N,numtype}(x.μ.+T, x.σ, x.ϕ, x.dirs)
+    return IsotropicGaussian{N,numtype}(x.μ.+T, x.σ, x.ϕ)
 end
 
 Base.:-(x::IsotropicGaussian, T::AbstractVector,) = x + (-T)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,29 +42,29 @@ const GMA = GaussianMixtureAlignment
     # rotation distances, no translation
     # anti-aligned (no rotation) and aligned (180 degree rotation)
     lb, ub = gauss_l2_bounds(x,y,RotationRegion(0.))
-    @test lb ≈ -GMA.overlap(7^2,2*σ^2,ϕ*ϕ, 1.) atol=1e-16
-    @test ub ≈ -GMA.overlap(7^2,2*σ^2,ϕ*ϕ, 1.)
+    @test lb ≈ -GMA.overlap(7^2,2*σ^2,ϕ*ϕ) atol=1e-16
+    @test ub ≈ -GMA.overlap(7^2,2*σ^2,ϕ*ϕ)
     lb, ub = gauss_l2_bounds(x,y,RotationRegion(RotationVec(0.,0.,π),SVector{3}(0.,0.,0.),0.))
-    @test lb ≈ ub ≈ -GMA.overlap(1,2*σ^2,ϕ*ϕ, 1.)
+    @test lb ≈ ub ≈ -GMA.overlap(1,2*σ^2,ϕ*ϕ)
     # region with closest alignment at 90 degree rotation
     lb = gauss_l2_bounds(x,y,RotationRegion(π/2/sqrt3))[1]
-    @test lb ≈ -GMA.overlap(5^2,2*σ^2,ϕ*ϕ, 1.)
+    @test lb ≈ -GMA.overlap(5^2,2*σ^2,ϕ*ϕ)
     lb = gauss_l2_bounds(x,y,RotationRegion(RotationVec(0,0,π/4),SVector{3}(0.,0.,0.),π/4/(sqrt3)))[1]
-    @test lb ≈ -GMA.overlap(5^2,2*σ^2,ϕ*ϕ, 1.) 
+    @test lb ≈ -GMA.overlap(5^2,2*σ^2,ϕ*ϕ) 
     
     # translation distance, no rotation
     # translation region centered at origin
     lb, ub = gauss_l2_bounds(x,y,TranslationRegion(1/sqrt3))
-    @test lb ≈ -GMA.overlap(6^2,2*σ^2,ϕ*ϕ, 1.)
-    @test ub ≈ -GMA.overlap(7^2,2*σ^2,ϕ*ϕ, 1.)
+    @test lb ≈ -GMA.overlap(6^2,2*σ^2,ϕ*ϕ)
+    @test ub ≈ -GMA.overlap(7^2,2*σ^2,ϕ*ϕ)
     # centered with translation of 1 in +x
     lb, ub = gauss_l2_bounds(x+SVector(1,0,0),y,TranslationRegion(1/sqrt3))
-    @test lb ≈ -GMA.overlap(7^2,2*σ^2,ϕ*ϕ, 1.)
-    @test ub ≈ -GMA.overlap(8^2,2*σ^2,ϕ*ϕ, 1.)
+    @test lb ≈ -GMA.overlap(7^2,2*σ^2,ϕ*ϕ)
+    @test ub ≈ -GMA.overlap(8^2,2*σ^2,ϕ*ϕ)
     # centered with translation of 3 in +y 
     lb, ub = gauss_l2_bounds(x+SVector(0,3,0),y,TranslationRegion(1/sqrt3))
-    @test lb ≈ -GMA.overlap((√(58)-1)^2,2*σ^2,ϕ*ϕ, 1.)
-    @test ub ≈ -GMA.overlap(58,2*σ^2,ϕ*ϕ, 1.)
+    @test lb ≈ -GMA.overlap((√(58)-1)^2,2*σ^2,ϕ*ϕ)
+    @test ub ≈ -GMA.overlap(58,2*σ^2,ϕ*ϕ)
 
 end
 


### PR DESCRIPTION
remove the `dirs` field from IsotropicGaussian objects so that they are definitely typed. Remove directional mismatch penalty from overlap scores