### PR TITLE
Support labels

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,8 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.7'
-          - 'nightly'
+          - '1.10'
+          - '1'
         os:
           - ubuntu-latest
         arch:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GaussianMixtureAlignment"
 uuid = "f2431ed1-b9c2-4fdb-af1b-a74d6c93b3b3"
 authors = ["Tom McGrath <tmcgrath325@gmail.com> and contributors"]
-version = "0.1.9"
+version = "0.1.10"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
@@ -20,6 +20,12 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
+[weakdeps]
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+
+[extensions]
+GaussianMixtureAlignmentMakieExt = "Makie"
+
 [compat]
 CoordinateTransformations = "0.6"
 Distances = "0.10"
@@ -27,6 +33,7 @@ Colors = "0.12"
 GenericLinearAlgebra = "0.3"
 GeometryBasics = "0.4"
 Hungarian = "0.7"
+Makie = "0.21"
 MakieCore = "0.6, 0.7, 0.8"
 MutableConvexHulls = "0.2"
 NearestNeighbors = "0.4.1"
@@ -35,7 +42,7 @@ PairedLinkedLists = "0.2"
 Requires = "1.3"
 Rotations = "1.4"
 StaticArrays = "1.5"
-julia = "1.7"
+julia = "1.10"
 
 [extras]
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"

--- a/ext/GaussianMixtureAlignmentMakieExt.jl
+++ b/ext/GaussianMixtureAlignmentMakieExt.jl
@@ -1,0 +1,9 @@
+module GaussianMixtureAlignmentMakieExt
+
+using GaussianMixtureAlignment
+using Makie
+
+# Needed to get legends working, see https://github.com/MakieOrg/Makie.jl/issues/1148
+Makie.get_plots(p::GaussianMixtureAlignment.GMMDisplay) = p.plots
+
+end

--- a/src/draw.jl
+++ b/src/draw.jl
@@ -65,9 +65,10 @@ function plot!(gd::GaussianDisplay{<:NTuple{<:Any, <:AbstractIsotropicGaussian}}
     gauss = [gd[i][] for i=1:length(gd)]
     disp = gd[:display][]
     color = gd[:color][]
+    label = gd[:label][]
     plotfun = disp == :wire ? wire_sphere! : ( disp == :solid ? solid_sphere! : throw(ArgumentError("Unrecognized display option: `$disp`")))
     for g in gauss
-        plotfun(gd, g.μ, g.σ; color=color)
+        plotfun(gd, g.μ, g.σ; color=color, label)
     end
     return gd
 end
@@ -77,6 +78,7 @@ end
         display = :wire,
         palette = DEFAULT_COLORS,
         color = nothing,
+        label = "",
     )
 end
 
@@ -86,9 +88,10 @@ function plot!(gd::GMMDisplay{<:NTuple{<:Any,<:AbstractIsotropicGMM}})
     disp = gd[:display][]
     color = gd[:color][]
     palette = gd[:palette][]
+    label = gd[:label][]
     for (i,gmm) in enumerate(gmms)
         col = isnothing(color) ? palette[(i-1) % len + 1] : color
-        gaussiandisplay!(gd, gmm.gaussians...; display=disp, color=col)
+        gaussiandisplay!(gd, gmm.gaussians...; display=disp, color=col, label)
     end
     return gd
 end
@@ -106,7 +109,7 @@ function plot!(gd::GMMDisplay{<:NTuple{<:Any,<:AbstractIsotropicMultiGMM{N,T,K}}
     for (i,k) in enumerate(allkeys)
         col = isnothing(color) ? palette[(i-1) % len + 1] : color
         for mgmm in mgmms
-            haskey(mgmm.gmms, k) && gmmdisplay!(gd, mgmm.gmms[k]; display=disp, color=col, palette=palette)
+            haskey(mgmm.gmms, k) && gmmdisplay!(gd, mgmm.gmms[k]; display=disp, color=col, palette=palette, label=string(k))
         end
     end
     return gd

--- a/test/draw.jl
+++ b/test/draw.jl
@@ -20,5 +20,5 @@ using Test
         :positive => IsotropicGMM([ch_g]),
         :steric => IsotropicGMM(s_gs)
     ))
-    gmmdisplay(gmm)
+    gmmdisplay(mgmmx)
 end


### PR DESCRIPTION
This requires overloading one function in Makie itself, so this defines an extension module. To make this easy, require Julia 1.10 as the new minimum version.

This also turns off testing against Julia `nightly`; if this package works on released Julia versions, that should be good enough (and if it doesn't work on Julia nightly, that's more a problem for the Julia developers to fix).