### PR TITLE
Evaluate GMM at a point

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GaussianMixtureAlignment"
 uuid = "f2431ed1-b9c2-4fdb-af1b-a74d6c93b3b3"
 authors = ["Tom McGrath <tmcgrath325@gmail.com> and contributors"]
-version = "0.2"
+version = "0.2.1"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/src/gogma/gmm.jl
+++ b/src/gogma/gmm.jl
@@ -61,8 +61,8 @@ weights(mgmm::AbstractMultiGMM) = vcat([weights(gmm) for (k,gmm) in mgmm.gmms]..
 widths(mgmm::AbstractMultiGMM) = vcat([widths(gmm) for (k,gmm) in mgmm.gmms]...)
 
 """
-A structure that defines an isotropic Gaussian distribution with the location of the mean, `μ`, standard deviation `σ`, 
-and scaling factor `ϕ`. 
+A structure that defines an isotropic Gaussian distribution with the location of the mean, `μ`, standard deviation `σ`,
+and scaling factor `ϕ`.
 
 """
 struct IsotropicGaussian{N,T} <: AbstractIsotropicGaussian{N,T}
@@ -80,8 +80,9 @@ end
 IsotropicGaussian(g::AbstractIsotropicGaussian) = IsotropicGaussian(g.μ, g.σ, g.ϕ)
 
 convert(::Type{IsotropicGaussian{N,T}}, g::AbstractIsotropicGaussian) where {N,T} = IsotropicGaussian(SVector{N,T}(g.μ), T(g.σ), T(g.ϕ))
-promote_rule(::Type{IsotropicGaussian{N,T}}, ::Type{IsotropicGaussian{N,S}}) where {N,T<:Real,S<:Real} = IsotropicGaussian{N,promote_type(T,S)} 
+promote_rule(::Type{IsotropicGaussian{N,T}}, ::Type{IsotropicGaussian{N,S}}) where {N,T<:Real,S<:Real} = IsotropicGaussian{N,promote_type(T,S)}
 
+(g::IsotropicGaussian)(pos::AbstractVector) = exp(-sum(abs2, pos-g.μ)/(2*g.σ^2))*g.ϕ
 
 """
 A collection of `IsotropicGaussian`s, making up a Gaussian Mixture Model (GMM).
@@ -95,9 +96,11 @@ IsotropicGMM(gmm::AbstractIsotropicGMM) = IsotropicGMM(gmm.gaussians)
 convert(t::Type{IsotropicGMM}, gmm::AbstractIsotropicGMM) = t(gmm.gaussians)
 promote_rule(::Type{IsotropicGMM{N,T}}, ::Type{IsotropicGMM{N,S}}) where {T,S,N} = IsotropicGMM{N,promote_type(T,S)}
 
+(gmm::IsotropicGMM)(pos::AbstractVector) = sum(g(pos) for g in gmm.gaussians)
+
 """
-A collection of labeled `IsotropicGMM`s, to each be considered separately during an alignment procedure. That is, 
-only alignment scores between `IsotropicGMM`s with the same key are considered when aligning two `MultiGMM`s. 
+A collection of labeled `IsotropicGMM`s, to each be considered separately during an alignment procedure. That is,
+only alignment scores between `IsotropicGMM`s with the same key are considered when aligning two `MultiGMM`s.
 """
 struct IsotropicMultiGMM{N,T,K} <: AbstractIsotropicMultiGMM{N,T,K}
     gmms::Dict{K, IsotropicGMM{N,T}}

--- a/src/gogma/overlap.jl
+++ b/src/gogma/overlap.jl
@@ -123,7 +123,7 @@ function force!(f::AbstractVector, x::AbstractIsotropicGMM, y::AbstractIsotropic
 end
 
 function force!(f::AbstractVector, x::AbstractMultiGMM, y::AbstractMultiGMM; interactions=nothing)
-    mpσ, mpϕ = pairwise_consts(x, y, interactions) 
+    mpσ, mpϕ = pairwise_consts(x, y, interactions)
     for k1 in keys(mpσ)
         for k2 in keys(mpσ[k1])
             # don't pass coef as a keyword argument, since the interaction coefficient is baked into mpϕ

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,8 +96,6 @@ end
     end
 end
 
-
-
 @testset "bounds for shrinking searchspace around an optimum" begin
     # two sets of points, each forming a 3-4-5 triangle
     xpts = [[0.,0.,0.], [3.,0.,0.,], [0.,4.,0.]]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,6 +96,8 @@ end
     end
 end
 
+
+
 @testset "bounds for shrinking searchspace around an optimum" begin
     # two sets of points, each forming a 3-4-5 triangle
     xpts = [[0.,0.,0.], [3.,0.,0.,], [0.,4.,0.]]
@@ -139,6 +141,17 @@ end
 
     # ROCS alignment should work perfectly for these GMMs
     @test isapprox(rocs_align(gmmx, gmmy).minimum, -overlap(gmmx,gmmx); atol=1E-12)
+end
+
+@testset "Evaluation at a point" begin
+    pts = [[0.,0.,0.], [3.,0.,0.,], [0.,4.,0.]]
+    σ = ϕ = 1.
+    gmm = IsotropicGMM([IsotropicGaussian(x, σ, ϕ) for x in pts])
+
+    pt = [1, 1, 1]
+    gpt = [g(pt) for g in gmm.gaussians]
+    @test gpt ≈ [exp(-3/2), exp(-6/2), exp(-11/2)]
+    @test gmm(pt) == sum(gpt)
 end
 
 @testset "MultiGMMs with interactions" begin


### PR DESCRIPTION
This supports evaluating a GMM `gmm` at a point `pt` with the syntax
`gmm(pt)`.