### PR TITLE
Provide more interface convenience functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GaussianMixtureAlignment"
 uuid = "f2431ed1-b9c2-4fdb-af1b-a74d6c93b3b3"
 authors = ["Tom McGrath <tmcgrath325@gmail.com> and contributors"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/src/GaussianMixtureAlignment.jl
+++ b/src/GaussianMixtureAlignment.jl
@@ -9,7 +9,7 @@ isotropic (spherical) Gaussian distributions.
 REPL help
 =========
 
-? followed by an algorith or constructor name will print help to the terminal. See: \n
+? followed by an algorithm or constructor name will print help to the terminal. See: \n
     \t?IsotropicGaussian \n
     \t?IsotropicGMM \n
     \t?IsotropicMultiGMM \n

--- a/src/draw.jl
+++ b/src/draw.jl
@@ -91,7 +91,7 @@ function plot!(gd::GMMDisplay{<:NTuple{<:Any,<:AbstractIsotropicGMM}})
     label = gd[:label][]
     for (i,gmm) in enumerate(gmms)
         col = isnothing(color) ? palette[(i-1) % len + 1] : color
-        gaussiandisplay!(gd, gmm.gaussians...; display=disp, color=col, label)
+        gaussiandisplay!(gd, gmm...; display=disp, color=col, label)
     end
     return gd
 end
@@ -103,13 +103,13 @@ function plot!(gd::GMMDisplay{<:NTuple{<:Any,<:AbstractIsotropicMultiGMM{N,T,K}}
     palette = gd[:palette][]
     allkeys = Set{K}()
     for mgmm in mgmms
-        allkeys = allkeys ∪ keys(mgmm.gmms)
+        allkeys = allkeys ∪ keys(mgmm)
     end
     len = length(allkeys)
     for (i,k) in enumerate(allkeys)
         col = isnothing(color) ? palette[(i-1) % len + 1] : color
         for mgmm in mgmms
-            haskey(mgmm.gmms, k) && gmmdisplay!(gd, mgmm.gmms[k]; display=disp, color=col, palette=palette, label=string(k))
+            haskey(mgmm, k) && gmmdisplay!(gd, mgmm[k]; display=disp, color=col, palette=palette, label=string(k))
         end
     end
     return gd


### PR DESCRIPTION
This fleshes out the interface of GMMs as vector- or set-like
(implementing `push!` and `pop!`), and MultiGMMs as dictionary-like
(implementing `valtype`, `get`, `get!`, `delete!`, and `empty!`). This
makes it easier to write code without needing to reach into internals.
The new interface functions are used to simplify some of the other code.