### PR TITLE
add LabeledIsotropicGMM

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,13 @@
 name = "GaussianMixtureAlignment"
 uuid = "f2431ed1-b9c2-4fdb-af1b-a74d6c93b3b3"
-authors = ["Tom McGrath <tmcgrath325@gmail.com> and contributors"]
 version = "0.3.0"
+authors = ["Tom McGrath <tmcgrath325@gmail.com> and contributors"]
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
+GaussianRandomVariables = "dc8732e6-f4b5-4f59-a2b3-73aaa378a5c6"
 GenericLinearAlgebra = "14197337-ba66-59df-a3e3-ca00e7dcff7a"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 Hungarian = "e91730f6-4275-51fb-a7a0-7064cfbd3b39"
@@ -19,6 +20,7 @@ PairedLinkedLists = "7a42b37b-ed3b-477a-9848-3661f53bb718"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+ThickGlobalOptimization = "8e345d7e-3ff0-4b54-95c6-2aef83a3a4ff"
 
 [weakdeps]
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"

--- a/src/GaussianMixtureAlignment.jl
+++ b/src/GaussianMixtureAlignment.jl
@@ -39,7 +39,7 @@ using Colors
 using CoordinateTransformations: kabsch_centered
 
 export AbstractGaussian, AbstractGMM
-export IsotropicGaussian, IsotropicGMM, IsotropicMultiGMM
+export IsotropicGaussian, IsotropicGMM, LabeledIsotropicGMM, IsotropicMultiGMM
 export overlap, force!, gogma_align, rot_gogma_align, trl_gogma_align, tiv_gogma_align
 export rocs_align
 export PointSet, MultiPointSet

--- a/src/gogma/bounds.jl
+++ b/src/gogma/bounds.jl
@@ -25,7 +25,7 @@ function pairwise_consts(gmmx::AbstractIsotropicGMM, gmmy::AbstractIsotropicGMM,
     return pσ, pϕ
 end
 
-function pairwise_consts(gmmx::LabeledIsotropicGMM{N,T,K}, gmmy::LabeledIsotropicGMM{N,S,K}, interactions::Dict{Tuple{K,K},V}) where {N,T,S,K,V<:Number}
+function pairwise_consts(gmmx::AbstractLabeledIsotropicGMM{N,T,K}, gmmy::AbstractLabeledIsotropicGMM{N,S,K}, interactions::Dict{Tuple{K,K},V}) where {N,T,S,K,V<:Number}
     @assert validate_interactions(interactions) "Interactions must not include redundant key pairs (i.e. (k1,k2) and (k2,k1))"
     t = promote_type(T, S, V)
     pσ, pϕ = zeros(t, length(gmmx), length(gmmy)), zeros(t, length(gmmx), length(gmmy))
@@ -45,7 +45,7 @@ function pairwise_consts(mgmmx::AbstractMultiGMM{N,T,K}, mgmmy::AbstractMultiGMM
     self_interactions = Dict{Tuple{K,K},t}()
     for key in keys(mgmmx.gmms) ∩ keys(mgmmy.gmms)
         self_interactions[(key,key)] = one(t)
-    end 
+    end
     pairwise_consts(mgmmx, mgmmy, self_interactions)
 end
 
@@ -58,7 +58,7 @@ function pairwise_consts(mgmmx::AbstractMultiGMM{N,T,K}, mgmmy::AbstractMultiGMM
     mpσ, mpϕ = Dict{K, Dict{K, Matrix{t}}}(), Dict{K, Dict{K,Matrix{t}}}()
     ukeys = unique(Iterators.flatten(keys(interactions)))
     for key1 in ukeys
-        if key1 ∈ xkeys 
+        if key1 ∈ xkeys
             push!(mpσ, key1 => Dict{K, Matrix{t}}())
             push!(mpϕ, key1 => Dict{K, Matrix{t}}())
             for key2 in ukeys
@@ -84,10 +84,10 @@ end
     lowerbound, upperbound = gauss_l2_bounds(x::Union{IsotropicGaussian, AbstractGMM}, y::Union{IsotropicGaussian, AbstractGMM}, σᵣ, σₜ)
     lowerbound, upperbound = gauss_l2_bounds(x, y, R::RotationVec, T::SVector{3}, σᵣ, σₜ)
 
-Finds the bounds for overlap between two isotropic Gaussian distributions, two isotropic GMMs, or `two sets of 
+Finds the bounds for overlap between two isotropic Gaussian distributions, two isotropic GMMs, or `two sets of
 labeled isotropic GMMs for a particular region in 6-dimensional rigid rotation space, defined by `R`, `T`, `σᵣ` and `σₜ`.
 
-`R` and `T` represent the rotation and translation, respectively, that are at the center of the uncertainty region. If they are not provided, 
+`R` and `T` represent the rotation and translation, respectively, that are at the center of the uncertainty region. If they are not provided,
 the uncertainty region is assumed to be centered at the origin (i.e. x has already been transformed).
 
 `σᵣ` and `σₜ` represent the sizes of the rotation and translation uncertainty regions.
@@ -121,9 +121,9 @@ function gauss_l2_bounds(gmmx::AbstractSingleGMM, gmmy::AbstractSingleGMM, R::Ro
     # sum bounds for each pair of points
     lb = 0.
     ub = 0.
-    for (i,x) in enumerate(gmmx.gaussians) 
+    for (i,x) in enumerate(gmmx.gaussians)
         for (j,y) in enumerate(gmmy.gaussians)
-            lb, ub = (lb, ub) .+ gauss_l2_bounds(x, y, R, T, σᵣ, σₜ, pσ[i,j], pϕ[i,j]; kwargs...)  
+            lb, ub = (lb, ub) .+ gauss_l2_bounds(x, y, R, T, σᵣ, σₜ, pσ[i,j], pϕ[i,j]; kwargs...)
         end
     end
     return lb, ub

--- a/src/gogma/gmm.jl
+++ b/src/gogma/gmm.jl
@@ -114,6 +114,23 @@ eltype(::Type{IsotropicGMM{N,T}}) where {N,T} = IsotropicGaussian{N,T}
 (gmm::IsotropicGMM)(pos::AbstractVector) = sum(g(pos) for g in gmm)
 
 """
+A collection of `IsotropicGaussian`s, as well as a collection of their associated labels, making up a Gaussian Mixture Model (GMM).
+"""
+struct LabeledIsotropicGMM{N,T,K} <: AbstractIsotropicGMM{N,T}
+    gaussians::Vector{IsotropicGaussian{N,T}}
+    labels::Vector{K}
+end
+
+LabeledIsotropicGMM{N,T,K}() where {N,T,K} = IsotropicGMM{N,T}(IsotropicGaussian{N,T}[], K[])
+
+convert(::Type{GMM}, gmm::LabeledIsotropicGMM) where GMM<:LabeledIsotropicGMM = GMM(gmm.gaussians, gmm.labels)
+promote_rule(::Type{LabeledIsotropicGMM{N,T,K}}, ::Type{LabeledIsotropicGMM{N,S,K}}) where {T,S,N,K} = LabeledIsotropicGMM{N,promote_type(T,S),K}
+eltype(::Type{LabeledIsotropicGMM{N,T}}) where {N,T} = IsotropicGaussian{N,T}
+
+(gmm::LabeledIsotropicGMM)(pos::AbstractVector) = sum(g(pos) for g in gmm)
+
+
+"""
 A collection of labeled `IsotropicGMM`s, to each be considered separately during an alignment procedure. That is,
 only alignment scores between `IsotropicGMM`s with the same key are considered when aligning two `MultiGMM`s.
 """

--- a/src/gogma/gmm.jl
+++ b/src/gogma/gmm.jl
@@ -5,25 +5,12 @@ import Base: eltype, keytype, valtype, length, size, getindex, iterate, convert,
 
 abstract type AbstractGaussian{N,T} end
 abstract type AbstractIsotropicGaussian{N,T} <: AbstractGaussian{N,T} end
-    # concrete subtypes:
-    #   IsotropicGaussian
-    #   AtomGaussian (MolecularGaussians.jl)
-    #   FeatureGaussian (MolecularGaussians.jl)
-
 abstract type AbstractGMM{N,T} <: AbstractModel{N,T} end
-
 abstract type AbstractSingleGMM{N,T} <: AbstractGMM{N,T} end
 abstract type AbstractIsotropicGMM{N,T} <: AbstractSingleGMM{N,T} end
-    # concrete subtypes:
-    #   IsotropicGMM
-    #   MolGMM (MolecularGaussians.jl)
-
+abstract type AbstractLabeledIsotropicGMM{N,T,K} <: AbstractIsotropicGMM{N,T} end
 abstract type AbstractMultiGMM{N,T,K} <: AbstractGMM{N,T} end
 abstract type AbstractIsotropicMultiGMM{N,T,K} <: AbstractMultiGMM{N,T,K} end
-    # concrete subtypes:
-    #   IsotropicMultiGMM
-    #   FeatureMolGMM (MolecularGaussians.jl)
-
 
 # # Base methods for Gaussians
 # numbertype(::AbstractGaussian{N,T}) where {N,T} = T
@@ -116,7 +103,7 @@ eltype(::Type{IsotropicGMM{N,T}}) where {N,T} = IsotropicGaussian{N,T}
 """
 A collection of `IsotropicGaussian`s, as well as a collection of their associated labels, making up a Gaussian Mixture Model (GMM).
 """
-struct LabeledIsotropicGMM{N,T,K} <: AbstractIsotropicGMM{N,T}
+struct LabeledIsotropicGMM{N,T,K} <: AbstractLabeledIsotropicGMM{N,T,K}
     gaussians::Vector{IsotropicGaussian{N,T}}
     labels::Vector{K}
 end

--- a/src/gogma/overlap.jl
+++ b/src/gogma/overlap.jl
@@ -50,7 +50,7 @@ function overlap(x::AbstractSingleGMM, y::AbstractSingleGMM, pσ=nothing, pϕ=no
     return ovlp
 end
 
-function overlap(x::LabeledIsotropicGMM, y::LabeledIsotropicGMM, pσ=nothing, pϕ=nothing, interactions::Dict = Dict())
+function overlap(x::AbstractLabeledIsotropicGMM, y::AbstractLabeledIsotropicGMM, pσ=nothing, pϕ=nothing, interactions::Dict = Dict())
     pσ, pϕ = pairwise_consts(x, y, interactions)
     return overlap(x, y, pσ, pϕ, nothing)
 end

--- a/src/gogma/overlap.jl
+++ b/src/gogma/overlap.jl
@@ -34,7 +34,7 @@ end
 
 Calculates the unnormalized overlap between two `AbstractSingleGMM` objects.
 """
-function overlap(x::AbstractSingleGMM, y::AbstractSingleGMM, pσ=nothing, pϕ=nothing)
+function overlap(x::AbstractSingleGMM, y::AbstractSingleGMM, pσ=nothing, pϕ=nothing, interactions::Nothing = nothing)
     # prepare pairwise widths and weights, if not provided
     if isnothing(pσ) && isnothing(pϕ)
         pσ, pϕ = pairwise_consts(x, y)
@@ -49,6 +49,12 @@ function overlap(x::AbstractSingleGMM, y::AbstractSingleGMM, pσ=nothing, pϕ=no
     end
     return ovlp
 end
+
+function overlap(x::LabeledIsotropicGMM, y::LabeledIsotropicGMM, pσ=nothing, pϕ=nothing, interactions::Dict = Dict())
+    pσ, pϕ = pairwise_consts(x, y, interactions)
+    return overlap(x, y, pσ, pϕ, nothing)
+end
+
 
 """
     ovlp = overlap(x::AbstractMultiGMM, y::AbstractMultiGMM)
@@ -113,9 +119,9 @@ function force!(f::AbstractVector, x::AbstractIsotropicGaussian, y::AbstractIsot
     end
 end
 
-function force!(f::AbstractVector, x::AbstractIsotropicGMM, y::AbstractIsotropicGMM, pσ=nothing, pϕ=nothing; kwargs...)
+function force!(f::AbstractVector, x::AbstractIsotropicGMM, y::AbstractIsotropicGMM, pσ=nothing, pϕ=nothing; interactions=nothing, kwargs...)
     if isnothing(pσ) && isnothing(pϕ)
-        pσ, pϕ = pairwise_consts(x, y)
+        pσ, pϕ = pairwise_consts(x, y, interactions)
     end
     for (i,gx) in enumerate(x.gaussians)
         force!(f, gx, y, pσ[i,:], pϕ[i,:]; kwargs...)

--- a/src/gogma/transformation.jl
+++ b/src/gogma/transformation.jl
@@ -22,6 +22,18 @@ end
 
 Base.:-(x::IsotropicGMM, T::AbstractVector,) = x + (-T)
 
+function Base.:*(R::AbstractMatrix{W}, x::LabeledIsotropicGMM{N,V,K}) where {N,V,W,K}
+    numtype = promote_type(V, W)
+    return LabeledIsotropicGMM{N,numtype,K}([R*g for g in x.gaussians], x.labels)
+end
+
+function Base.:+(x::LabeledIsotropicGMM{N,V,K}, T::AbstractVector{W}) where {N,V,W,K}
+    numtype = promote_type(V, W)
+    return LabeledIsotropicGMM{N,numtype,K}([g+T for g in x.gaussians], x.labels)
+end
+
+Base.:-(x::LabeledIsotropicGMM, T::AbstractVector,) = x + (-T)
+
 function  Base.:*(R::AbstractMatrix{W}, x::IsotropicMultiGMM{N,V,K}) where {N,V,K,W}
     numtype = promote_type(V, W)
     gmmdict = Dict{K, IsotropicGMM{N,numtype}}()

--- a/src/gogma/transformation.jl
+++ b/src/gogma/transformation.jl
@@ -22,17 +22,17 @@ end
 
 Base.:-(x::IsotropicGMM, T::AbstractVector,) = x + (-T)
 
-function Base.:*(R::AbstractMatrix{W}, x::LabeledIsotropicGMM{N,V,K}) where {N,V,W,K}
+function Base.:*(R::AbstractMatrix{W}, x::AbstractLabeledIsotropicGMM{N,V,K}) where {N,V,W,K}
     numtype = promote_type(V, W)
     return LabeledIsotropicGMM{N,numtype,K}([R*g for g in x.gaussians], x.labels)
 end
 
-function Base.:+(x::LabeledIsotropicGMM{N,V,K}, T::AbstractVector{W}) where {N,V,W,K}
+function Base.:+(x::AbstractLabeledIsotropicGMM{N,V,K}, T::AbstractVector{W}) where {N,V,W,K}
     numtype = promote_type(V, W)
     return LabeledIsotropicGMM{N,numtype,K}([g+T for g in x.gaussians], x.labels)
 end
 
-Base.:-(x::LabeledIsotropicGMM, T::AbstractVector,) = x + (-T)
+Base.:-(x::AbstractLabeledIsotropicGMM, T::AbstractVector,) = x + (-T)
 
 function  Base.:*(R::AbstractMatrix{W}, x::IsotropicMultiGMM{N,V,K}) where {N,V,K,W}
     numtype = promote_type(V, W)


### PR DESCRIPTION
This adds an alternative to MultiIsotropicGMM to avoid the need for duplicate features (e.g. an atom with both a charge as well as a volume), which can reduce the number of distances to be computed between two models in some cases