### PR TITLE
Add LabeledIsotropicGMM

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GaussianMixtureAlignment"
 uuid = "f2431ed1-b9c2-4fdb-af1b-a74d6c93b3b3"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Tom McGrath <tmcgrath325@gmail.com> and contributors"]
 
 [deps]

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -23,6 +23,7 @@ AbstractGMM
 IsotropicGaussian
 IsotropicGMM
 IsotropicMultiGMM
+LabeledIsotropicGMM
 ```
 
 ### Point set types

--- a/src/GaussianMixtureAlignment.jl
+++ b/src/GaussianMixtureAlignment.jl
@@ -28,7 +28,7 @@ using Rotations: Rotations, AngleAxis, RotationVec
 using StaticArrays: StaticArrays, SMatrix, SVector
 
 export AbstractGaussian, AbstractGMM
-export IsotropicGaussian, IsotropicGMM, IsotropicMultiGMM
+export IsotropicGaussian, IsotropicGMM, LabeledIsotropicGMM, IsotropicMultiGMM
 export overlap, force!, force, gogma_align, rot_gogma_align, trl_gogma_align, tiv_gogma_align
 export rocs_align
 export PointSet, MultiPointSet

--- a/src/gogma/bounds.jl
+++ b/src/gogma/bounds.jl
@@ -39,6 +39,30 @@ function pairwise_consts(gmmx::AbstractIsotropicGMM, gmmy::AbstractIsotropicGMM,
     return pσ, pϕ
 end
 
+function pairwise_consts(gmmx::AbstractLabeledIsotropicGMM{N, T, K}, gmmy::AbstractLabeledIsotropicGMM{N, S, K}, interactions::Nothing = nothing) where {N, T, S, K}
+    t = promote_type(T, S)
+    self_interactions = Dict{Tuple{K, K}, t}()
+    for label in unique(gmmx.labels) ∩ unique(gmmy.labels)
+        self_interactions[(label, label)] = one(t)
+    end
+    return pairwise_consts(gmmx, gmmy, self_interactions)
+end
+
+function pairwise_consts(gmmx::AbstractLabeledIsotropicGMM{N, T, K}, gmmy::AbstractLabeledIsotropicGMM{N, S, K}, interactions::Dict{Tuple{K, K}, V}) where {N, T, S, K, V <: Number}
+    validate_interactions(interactions) || throw(ArgumentError("Interactions must not include redundant key pairs (i.e. (k1,k2) and (k2,k1))"))
+    t = promote_type(T, S, V)
+    pσ, pϕ = zeros(t, length(gmmx), length(gmmy)), zeros(t, length(gmmx), length(gmmy))
+    for (i, gaussx) in enumerate(gmmx.gaussians)
+        for (j, gaussy) in enumerate(gmmy.gaussians)
+            keypair = (gmmx.labels[i], gmmy.labels[j])
+            keypair = haskey(interactions, keypair) ? keypair : (keypair[2], keypair[1])
+            pσ[i, j] = gaussx.σ^2 + gaussy.σ^2
+            pϕ[i, j] = (haskey(interactions, keypair) ? interactions[keypair] : zero(t)) * gaussx.ϕ * gaussy.ϕ
+        end
+    end
+    return pσ, pϕ
+end
+
 function pairwise_consts(mgmmx::AbstractMultiGMM{N, T, K}, mgmmy::AbstractMultiGMM{N, S, K}, interactions::Nothing = nothing) where {N, T, S, K}
     t = promote_type(T, S)
     self_interactions = Dict{Tuple{K, K}, t}()

--- a/src/gogma/gmm.jl
+++ b/src/gogma/gmm.jl
@@ -29,6 +29,15 @@ abstract type AbstractIsotropicGMM{N, T} <: AbstractSingleGMM{N, T} end
 #   IsotropicGMM
 #   MolGMM (MolecularGaussians.jl)
 
+"""
+Abstract base type for single isotropic GMMs whose Gaussians each carry a label of type `K`.
+Overlap between two such GMMs is restricted to Gaussian pairs whose labels interact, as
+specified by an `interactions` dictionary. Concrete implementation: `LabeledIsotropicGMM`.
+"""
+abstract type AbstractLabeledIsotropicGMM{N, T, K} <: AbstractIsotropicGMM{N, T} end
+# concrete subtypes:
+#   LabeledIsotropicGMM
+
 abstract type AbstractMultiGMM{N, T, K} <: AbstractGMM{N, T} end
 abstract type AbstractIsotropicMultiGMM{N, T, K} <: AbstractMultiGMM{N, T, K} end
 # concrete subtypes:
@@ -127,6 +136,35 @@ promote_rule(::Type{IsotropicGMM{N, T}}, ::Type{IsotropicGMM{N, S}}) where {T, S
 eltype(::Type{IsotropicGMM{N, T}}) where {N, T} = IsotropicGaussian{N, T}
 
 (gmm::IsotropicGMM)(pos::AbstractVector) = sum(g(pos) for g in gmm)
+
+"""
+    LabeledIsotropicGMM(gaussians, labels)
+
+Gaussian Mixture Model in `N` dimensions pairing a vector of `IsotropicGaussian{N,T}`
+components (in `.gaussians`) with a vector of per-Gaussian labels of type `K` (in `.labels`).
+The two vectors must have equal length. Unlike `IsotropicMultiGMM`, which groups Gaussians
+into keyed sub-GMMs, every Gaussian carries its own label; an `interactions` dictionary then
+selects which label pairs contribute to overlap (see [`overlap`](@ref) and `pairwise_consts`).
+"""
+struct LabeledIsotropicGMM{N, T, K} <: AbstractLabeledIsotropicGMM{N, T, K}
+    gaussians::Vector{IsotropicGaussian{N, T}}
+    labels::Vector{K}
+    function LabeledIsotropicGMM{N, T, K}(gaussians, labels) where {N, T, K}
+        length(gaussians) == length(labels) ||
+            throw(DimensionMismatch("number of Gaussians ($(length(gaussians))) must match number of labels ($(length(labels)))"))
+        return new{N, T, K}(gaussians, labels)
+    end
+end
+
+LabeledIsotropicGMM(gaussians::AbstractVector{IsotropicGaussian{N, T}}, labels::AbstractVector{K}) where {N, T, K} = LabeledIsotropicGMM{N, T, K}(gaussians, labels)
+LabeledIsotropicGMM(gmm::AbstractLabeledIsotropicGMM) = LabeledIsotropicGMM(gmm.gaussians, gmm.labels)
+LabeledIsotropicGMM{N, T, K}() where {N, T, K} = LabeledIsotropicGMM{N, T, K}(IsotropicGaussian{N, T}[], K[])
+
+convert(::Type{GMM}, gmm::AbstractLabeledIsotropicGMM) where {GMM <: LabeledIsotropicGMM} = GMM(gmm.gaussians, gmm.labels)
+promote_rule(::Type{LabeledIsotropicGMM{N, T, K}}, ::Type{LabeledIsotropicGMM{N, S, K}}) where {N, T, S, K} = LabeledIsotropicGMM{N, promote_type(T, S), K}
+eltype(::Type{LabeledIsotropicGMM{N, T, K}}) where {N, T, K} = IsotropicGaussian{N, T}
+
+(gmm::LabeledIsotropicGMM)(pos::AbstractVector) = sum(g(pos) for g in gmm)
 
 """
     IsotropicMultiGMM(gmms)

--- a/src/gogma/overlap.jl
+++ b/src/gogma/overlap.jl
@@ -53,6 +53,19 @@ function overlap(x::AbstractSingleGMM, y::AbstractSingleGMM, pσ = nothing, pϕ 
 end
 
 """
+    ovlp = overlap(x::AbstractLabeledIsotropicGMM, y::AbstractLabeledIsotropicGMM; interactions=nothing)
+
+Calculate the unnormalized overlap between two `AbstractLabeledIsotropicGMM` objects. The
+optional keyword argument `interactions` is a dictionary mapping `(label1, label2)` pairs to
+coefficient values; see `pairwise_consts` for the expected format. When omitted, only Gaussians
+with equal labels contribute, each with coefficient 1.
+"""
+function overlap(x::AbstractLabeledIsotropicGMM, y::AbstractLabeledIsotropicGMM; interactions = nothing)
+    pσ, pϕ = pairwise_consts(x, y, interactions)
+    return overlap(x, y, pσ, pϕ)
+end
+
+"""
     ovlp = overlap(x::AbstractMultiGMM, y::AbstractMultiGMM; interactions=nothing)
 
 Calculate the unnormalized overlap between two `AbstractMultiGMM` objects. The optional
@@ -141,6 +154,16 @@ end
 function force!(f::AbstractVector, x::AbstractIsotropicGMM, y::AbstractIsotropicGMM, pσ = nothing, pϕ = nothing; kwargs...)
     if isnothing(pσ) && isnothing(pϕ)
         pσ, pϕ = pairwise_consts(x, y)
+    end
+    for (i, gx) in enumerate(x.gaussians)
+        force!(f, gx, y, pσ[i, :], pϕ[i, :]; kwargs...)
+    end
+    return
+end
+
+function force!(f::AbstractVector, x::AbstractLabeledIsotropicGMM, y::AbstractLabeledIsotropicGMM, pσ = nothing, pϕ = nothing; interactions = nothing, kwargs...)
+    if isnothing(pσ) && isnothing(pϕ)
+        pσ, pϕ = pairwise_consts(x, y, interactions)
     end
     for (i, gx) in enumerate(x.gaussians)
         force!(f, gx, y, pσ[i, :], pϕ[i, :]; kwargs...)

--- a/src/gogma/transformation.jl
+++ b/src/gogma/transformation.jl
@@ -22,6 +22,18 @@ end
 
 Base.:-(x::IsotropicGMM, T::AbstractVector) = x + (-T)
 
+function Base.:*(R::AbstractMatrix{W}, x::AbstractLabeledIsotropicGMM{N, V, K}) where {N, V, K, W}
+    numtype = promote_type(V, W)
+    return LabeledIsotropicGMM{N, numtype, K}([R * g for g in x.gaussians], x.labels)
+end
+
+function Base.:+(x::AbstractLabeledIsotropicGMM{N, V, K}, T::AbstractVector{W}) where {N, V, K, W}
+    numtype = promote_type(V, W)
+    return LabeledIsotropicGMM{N, numtype, K}([g + T for g in x.gaussians], x.labels)
+end
+
+Base.:-(x::AbstractLabeledIsotropicGMM, T::AbstractVector) = x + (-T)
+
 function Base.:*(R::AbstractMatrix{W}, x::IsotropicMultiGMM{N, V, K}) where {N, V, K, W}
     numtype = promote_type(V, W)
     gmmdict = Dict{K, IsotropicGMM{N, numtype}}()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -511,6 +511,65 @@ end
     res = gogma_align(randtform(mgmmx), mgmmy; interactions = interactions, maxsplits = 5.0e3, nextblockfun = GMA.randomblock)
 end
 
+@testset "LabeledIsotropicGMM" begin
+    g1 = IsotropicGaussian([0.0, 0.0, 0.0], 1.0, 1.0)
+    g2 = IsotropicGaussian([1.0, 0.0, 0.0], 1.0, 1.0)
+    x = LabeledIsotropicGMM([g1, g2], [:A, :B])
+
+    # interface and supertypes
+    @test x isa GMA.AbstractLabeledIsotropicGMM{3, Float64, Symbol}
+    @test x isa GMA.AbstractIsotropicGMM
+    @test length(x) == 2
+    @test x[2] == g2
+    @test collect(x) == [g1, g2]              # iterate
+    @test eltype(x) === eltype(typeof(x)) === IsotropicGaussian{3, Float64}
+
+    # constructors
+    xcopy = LabeledIsotropicGMM(x)
+    @test xcopy.gaussians == x.gaussians && xcopy.labels == x.labels
+    empty_gmm = LabeledIsotropicGMM{3, Float64, Symbol}()
+    @test isempty(empty_gmm) && empty_gmm isa LabeledIsotropicGMM{3, Float64, Symbol}
+    @test_throws DimensionMismatch LabeledIsotropicGMM([g1, g2], [:A])
+
+    # convert and promote
+    @test convert(LabeledIsotropicGMM{3, Float32, Symbol}, x) isa LabeledIsotropicGMM{3, Float32, Symbol}
+    xf32 = LabeledIsotropicGMM([IsotropicGaussian([0.0f0, 0.0f0, 0.0f0], 1.0f0, 1.0f0)], [:A])
+    @test promote_type(typeof(x), typeof(xf32)) === LabeledIsotropicGMM{3, Float64, Symbol}
+
+    # transformations preserve labels and produce a LabeledIsotropicGMM
+    R = RotationVec(0.3, 0.1, -0.2)
+    @test R * x isa LabeledIsotropicGMM{3, Float64, Symbol}
+    @test (R * x).labels == x.labels
+    @test (x + SVector(1.0, 2.0, 3.0)).labels == x.labels
+    @test [g.μ for g in (x - SVector(1.0, 0.0, 0.0))] == [SVector(-1.0, 0.0, 0.0), SVector(0.0, 0.0, 0.0)]
+
+    # overlap: default uses same-label pairs only, each with coefficient 1
+    y = LabeledIsotropicGMM(
+        [
+            IsotropicGaussian([0.5, 0.2, 0.0], 1.0, 1.0),
+            IsotropicGaussian([1.7, 0.0, 0.3], 1.0, 1.0),
+        ], [:A, :B]
+    )
+    same_label = overlap(g1, y.gaussians[1]) + overlap(g2, y.gaussians[2])
+    @test overlap(x, y) ≈ same_label
+    @test overlap(x, y) ≈ overlap(x, y; interactions = Dict((:A, :A) => 1.0, (:B, :B) => 1.0))
+    @test overlap(x, y; interactions = Dict{Tuple{Symbol, Symbol}, Float64}()) == 0.0
+    @test !(overlap(x, y; interactions = Dict((:A, :B) => 1.0)) ≈ overlap(x, y))
+
+    # overlap is invariant when the same rigid transform is applied to both
+    @test overlap(R * x, R * y) ≈ overlap(x, y)
+
+    # redundant key pairs are rejected
+    @test_throws ArgumentError overlap(x, y; interactions = Dict((:A, :B) => 1.0, (:B, :A) => 1.0))
+    @test_throws "must not include redundant key pairs" GMA.pairwise_consts(x, y, Dict((:A, :B) => 1.0, (:B, :A) => 1.0))
+
+    # force and force! agree, and interactions change the result
+    f = zeros(3)
+    force!(f, x, y)
+    @test f ≈ force(x, y)
+    @test !(force(x, y) ≈ force(x, y; interactions = Dict((:A, :B) => 1.0)))
+end
+
 @testset "Forces" begin
     μx = randn(SVector{3, Float64})
     μy = randn(SVector{3, Float64})


### PR DESCRIPTION
This Introduces `LabeledIsotropicGMM`, a single isotropic GMM that pairs each Gaussian with a label, as a lighter-weight alternative to `IsotropicMultiGMM` for per-Gaussian labels. An interactions dictionary selects which label pairs contribute to overlap; when omitted, only equal-label pairs interact, each with coefficient 1, matching `AbstractMultiGMM`.

It also adds the `AbstractLabeledIsotropicGMM{N,T,K}` abstract layer (unexported, an extension point for downstream packages) with `pairwise_consts`, `overlap`, `force!`, and rigid-transform methods.