### PR TITLE
Add extension for ThickGlobalOptimization.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,10 +20,14 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [weakdeps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
+IntervalFastMath = "f385d984-c960-11e8-171c-977bba6b62a4"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+ThickGlobalOptimization = "8e345d7e-3ff0-4b54-95c6-2aef83a3a4ff"
+ThickNumbers = "b57aa878-5b76-4266-befc-f8e007760995"
 
 [extensions]
 GaussianMixtureAlignmentMakieExt = ["Colors", "GeometryBasics", "Makie"]
+GaussianMixtureAlignmentThickExt = ["IntervalFastMath", "ThickGlobalOptimization", "ThickNumbers"]
 
 [compat]
 ADTypes = "1"
@@ -37,6 +41,7 @@ ForwardDiff = "0.10, 1"
 GenericLinearAlgebra = "0.3"
 GeometryBasics = "0.5"
 Hungarian = "0.7"
+IntervalFastMath = "0.3.2, 0.4"
 IntervalSets = "0.7"
 LinearAlgebra = "1.10"
 Makie = "0.24"
@@ -48,6 +53,8 @@ PairedLinkedLists = "0.3"
 Rotations = "1.4, 1.5, 1.6, 1.7"
 StaticArrays = "1.5"
 Test = "1.10"
+ThickGlobalOptimization = "1"
+ThickNumbers = "1"
 julia = "1.10"
 
 [extras]

--- a/ext/GaussianMixtureAlignmentThickExt.jl
+++ b/ext/GaussianMixtureAlignmentThickExt.jl
@@ -1,0 +1,210 @@
+module GaussianMixtureAlignmentThickExt
+
+# ThickGlobalOptimization-based global search. This extension provides `thick_gogma_align` and
+# its low-level driver `globalalign`, which align one fixed GMM against one or more mobile GMMs
+# simultaneously by branch-and-bound minimization of the negated L2 overlap. The search runs on
+# ThickGlobalOptimization's `thicksearch`; per-node bounds reuse the core `gauss_l2_bounds` /
+# `overlap` / `pairwise_consts` machinery, wrapped into ThickNumbers intervals.
+
+using GaussianMixtureAlignment: AbstractModel, AbstractGMM, SearchRegion, RotationRegion,
+    TranslationRegion, GlobalAlignmentResult, numbertype, dims, translation_limit,
+    gauss_l2_bounds, build_tform
+import GaussianMixtureAlignment: globalalign, thick_gogma_align, pairwise_consts, overlap,
+    UncertaintyRegion
+
+using StaticArrays: SVector
+using Rotations: RotationVec
+using CoordinateTransformations: AffineMap
+using ThickGlobalOptimization: thicksearch, SearchBox, bisect
+using ThickNumbers: lohi, mid, wid
+using IntervalFastMath: Interval
+import Optim
+using ADTypes: AutoForwardDiff
+
+# An already-transformed mobile is bounded around its current position; the identity rotation
+# and zero translation reproduce the core `gauss_l2_bounds(x, y, R, T, σᵣ, σₜ, …)` distance.
+const IDENTITY_ROTATION = RotationVec(0.0, 0.0, 0.0)
+const ZERO_TRANSLATION = SVector{3}(0.0, 0.0, 0.0)
+
+lohi_interval(lo, hi) = lohi(Interval, lo, hi)
+
+## SearchRegion <-> SearchBox bridge
+
+# A `SearchBox` interval per rigid-transformation coordinate: the three rotation-vector
+# components (half-width `σᵣ`) followed by the three translation components (half-width `σₜ`).
+function searchbox(sr::UncertaintyRegion)
+    R, T, σᵣ, σₜ = sr.R, sr.T, sr.σᵣ, sr.σₜ
+    return SearchBox(
+        lohi(Interval, R.sx - σᵣ, R.sx + σᵣ),
+        lohi(Interval, R.sy - σᵣ, R.sy + σᵣ),
+        lohi(Interval, R.sz - σᵣ, R.sz + σᵣ),
+        lohi(Interval, T[1] - σₜ, T[1] + σₜ),
+        lohi(Interval, T[2] - σₜ, T[2] + σₜ),
+        lohi(Interval, T[3] - σₜ, T[3] + σₜ),
+    )
+end
+
+function searchbox(srs::AbstractVector{<:UncertaintyRegion})
+    intervals = reduce(vcat, [collect(searchbox(sr).box) for sr in srs])
+    return SearchBox(intervals)
+end
+
+# Reconstruct the `i`-th (zero-based) mobile's region from a `6N`-dimensional box.
+function blockregion(box::SearchBox, i::Integer = 0)
+    o = 6i
+    return UncertaintyRegion(
+        RotationVec(mid(box[o + 1]), mid(box[o + 2]), mid(box[o + 3])),
+        SVector{3}(mid(box[o + 4]), mid(box[o + 5]), mid(box[o + 6])),
+        wid(box[o + 1]) / 2, wid(box[o + 4]) / 2,
+    )
+end
+
+UncertaintyRegion(box::SearchBox) = blockregion(box, 0)
+
+# Split the rigid block (six coordinates) with the largest rotation-by-translation extent.
+function bisect_largest_rigid(box::SearchBox{N}) where {N}
+    nblocks = N ÷ 6
+    maxblock = argmax(i -> wid(box[6 * (i - 1) + 1]) * wid(box[6 * (i - 1) + 4]), 1:nblocks)
+    o = 6 * (maxblock - 1)
+    return bisect(box, (o + 1):(o + 6))
+end
+
+## Multiple-GMM overlap and pairwise constants (over `[y, xs...]`)
+
+function pairwise_consts(y::AbstractGMM, xs::AbstractVector{<:AbstractGMM}, interactions = nothing)
+    t = promote_type(numbertype(y), numbertype.(xs)...)
+    ms = [y, xs...]
+    n = length(ms)
+    pσ = Matrix{Matrix{t}}(undef, n, n)
+    pϕ = Matrix{Matrix{t}}(undef, n, n)
+    for i in 1:n, j in 1:n
+        pσ[i, j], pϕ[i, j] = pairwise_consts(ms[i], ms[j], interactions)
+    end
+    return pσ, pϕ
+end
+
+# Total overlap when all mobiles are aligned to the fixed `y` and to one another.
+function overlap(y::AbstractGMM, xs::AbstractVector{<:AbstractGMM}, pσ = nothing, pϕ = nothing, interactions = nothing)
+    if isnothing(pσ) && isnothing(pϕ)
+        pσ, pϕ = pairwise_consts(y, xs, interactions)
+    end
+    ovlp = zero(promote_type(numbertype(y), numbertype.(xs)...))
+    for (i, xi) in enumerate(xs)
+        ovlp += overlap(y, xi, pσ[1, i + 1], pϕ[1, i + 1])
+        for j in (i + 1):length(xs)
+            ovlp += overlap(xi, xs[j], pσ[i + 1, j + 1], pϕ[i + 1, j + 1])
+        end
+    end
+    return ovlp
+end
+
+## Bounds
+
+# Interval bound on the negated overlap for an already-transformed pair with residual rotation
+# uncertainty `σᵣ` and translation uncertainty `σₜ`.
+interval_bounds(x, y, σᵣ, σₜ, pσ, pϕ; lohifun = lohi_interval) =
+    lohifun(gauss_l2_bounds(x, y, IDENTITY_ROTATION, ZERO_TRANSLATION, σᵣ, σₜ, pσ, pϕ)...)
+
+function thick_l2_bounds!(tformedxs, y::AbstractGMM, xs::AbstractVector{<:AbstractGMM}, blocks::AbstractVector{<:SearchRegion}, pσ, pϕ; lohifun = lohi_interval)
+    for (i, (x, b)) in enumerate(zip(xs, blocks))
+        tformedxs[i] = b.R * x + b.T
+    end
+    bnds = lohifun(0.0, 0.0)
+    for (i, xi) in enumerate(tformedxs)
+        bnds += interval_bounds(xi, y, blocks[i].σᵣ, blocks[i].σₜ, pσ[i + 1, 1], pϕ[i + 1, 1]; lohifun)
+        for j in (i + 1):length(xs)
+            bnds += interval_bounds(xi, tformedxs[j], blocks[i].σᵣ + blocks[j].σᵣ, blocks[i].σₜ + blocks[j].σₜ, pσ[i + 1, j + 1], pϕ[i + 1, j + 1]; lohifun)
+        end
+    end
+    return bnds
+end
+
+## Local search
+
+# `thicksearch`'s default `localfun` drives Optim with the Optim-1 `autodiff = :forward` symbol,
+# which Optim 2 rejects. This local search uses the Optim 2 / ADTypes backend, and lets
+# `thick_gogma_align` control the autodiff backend the way `gogma_align` does. Returns the
+# `(minimum, minimizer, f_calls)` triple `thicksearch` expects from a `localfun`.
+#
+# `f_calls_limit = maxevals` bounds each refinement: the `RotationVec` exponential map is singular
+# at the identity, so a block centered at zero rotation yields a `NaN` gradient and an unbounded
+# line search would stall there. The cap turns that into a harmless no-op while subdivided blocks
+# (nonzero rotation centers) still refine.
+function thick_localsearch(func, box; autodiff = AutoForwardDiff(), maxevals = 100, inner_optimizer = Optim.LBFGS(), kwargs...)
+    initial_x = collect(mid(box))
+    options = Optim.Options(; f_calls_limit = maxevals, iterations = maxevals, kwargs...)
+    results = Optim.optimize(func, initial_x, inner_optimizer, options; autodiff)
+    return Optim.minimum(results), Optim.minimizer(results), results.f_calls
+end
+
+## Result translation
+
+# `thicksearch` reports no termination reason, so infer one of the strings
+# `GaussianMixtureAlignment.converged` recognizes: an empty scheduler means the queue was
+# exhausted; otherwise a closed bounds gap means the tolerance was met, and anything else is a
+# limit. (An authoritative reason would come from a termination field on `ThickSearchResult`.)
+function thick_terminated_by(res, atol, rtol)
+    isempty(res.scheduler) && return "priority queue empty"
+    gap = abs(res.globalrv - res.globallb)
+    if (atol > 0 && gap < atol) || (rtol > 0 && gap / max(abs(res.globalrv), abs(res.globallb)) < rtol)
+        return "optimum within tolerance"
+    end
+    return "terminated early"
+end
+
+# Translate a `ThickSearchResult` into a `GlobalAlignmentResult` for the mobile occupying the
+# `params` coordinates of the flat minimizer. `GlobalAlignmentResult` cannot embed the
+# `ThickSearchResult` — ThickGlobalOptimization is a weak dependency. `stagnant_splits` is `0`:
+# `thicksearch` exposes no since-last-improvement count.
+# Unexplored regions left in the scheduler. `thicksearch`'s default `ConvexHullScheduler` keeps
+# them in a `.structure` hull; other schedulers expose no generic count, so fall back to 0.
+remaining_blocks(scheduler) = hasproperty(scheduler, :structure) ? length(scheduler.structure) : 0
+
+function alignment_result(res, x::AbstractModel, y::AbstractModel, params::UnitRange, terminated_by)
+    p = Tuple(res.bestminimizer[params])
+    progress = [(c, v, Tuple(m[params])) for (c, m, v) in res.progress]
+    return GlobalAlignmentResult(
+        x, y, res.globalrv, res.globallb, build_tform(AffineMap, p), p,
+        res.fevals, res.boxsplits, remaining_blocks(res.scheduler), 0, progress, terminated_by,
+    )
+end
+
+## Drivers
+
+function globalalign(fixed::AbstractModel, mobiles::AbstractVector{<:AbstractModel};
+        searchspace = nothing, blockfun = UncertaintyRegion, boxsplitter = bisect_largest_rigid,
+        objfun, boundsfun, kwargs...
+    )
+    all(x -> dims(x) == dims(fixed), mobiles) || throw(ArgumentError("Dimensionality of the GMMs must be equal"))
+    if isnothing(searchspace)
+        tlimit = translation_limit(fixed, first(mobiles))
+        searchspace = [blockfun(tlimit) for _ in mobiles]
+    end
+    box = searchbox(searchspace)
+    return thicksearch(objfun, box; boxsplitter, boundsfun, kwargs...)
+end
+
+function thick_gogma_align(y::AbstractGMM, xs::AbstractVector{<:AbstractGMM}; interactions = nothing, lohifun = lohi_interval, autodiff = AutoForwardDiff(), atol = 0.01, rtol = 0.01, kwargs...)
+    pσ, pϕ = pairwise_consts(y, xs, interactions)
+    tformedxs = collect(xs)
+    nmobiles = length(xs)
+
+    boundsfun = function (box)
+        blocks = [blockregion(box, i) for i in 0:(nmobiles - 1)]
+        return thick_l2_bounds!(tformedxs, y, xs, blocks, pσ, pϕ; lohifun)
+    end
+    objfun = function (X)
+        local_tformedxs = [RotationVec(X[6i + 1], X[6i + 2], X[6i + 3]) * xs[i + 1] + SVector{3}(X[6i + 4], X[6i + 5], X[6i + 6]) for i in 0:(nmobiles - 1)]
+        return -overlap(y, local_tformedxs, pσ, pϕ, interactions)
+    end
+    localfun(func, box; kw...) = thick_localsearch(func, box; autodiff, kw...)
+
+    res = globalalign(y, xs; boxsplitter = bisect_largest_rigid, boundsfun, objfun, localfun, atol, rtol, kwargs...)
+    terminated_by = thick_terminated_by(res, atol, rtol)
+    return [alignment_result(res, xs[i + 1], y, (6i + 1):(6i + 6), terminated_by) for i in 0:(nmobiles - 1)]
+end
+
+thick_gogma_align(fixed::AbstractGMM, mobile::AbstractGMM; kwargs...) =
+    only(thick_gogma_align(fixed, [mobile]; kwargs...))
+
+end

--- a/ext/GaussianMixtureAlignmentThickExt.jl
+++ b/ext/GaussianMixtureAlignmentThickExt.jl
@@ -6,9 +6,8 @@ module GaussianMixtureAlignmentThickExt
 # ThickGlobalOptimization's `thicksearch`; per-node bounds reuse the core `gauss_l2_bounds` /
 # `overlap` / `pairwise_consts` machinery, wrapped into ThickNumbers intervals.
 
-using GaussianMixtureAlignment: AbstractModel, AbstractGMM, SearchRegion, RotationRegion,
-    TranslationRegion, GlobalAlignmentResult, numbertype, dims, translation_limit,
-    gauss_l2_bounds, build_tform
+using GaussianMixtureAlignment: AbstractModel, AbstractGMM, SearchRegion,
+    GlobalAlignmentResult, numbertype, dims, translation_limit, gauss_l2_bounds, build_tform
 import GaussianMixtureAlignment: globalalign, thick_gogma_align, pairwise_consts, overlap,
     UncertaintyRegion
 
@@ -18,7 +17,7 @@ using CoordinateTransformations: AffineMap
 using ThickGlobalOptimization: thicksearch, SearchBox, bisect
 using ThickNumbers: lohi, mid, wid
 using IntervalFastMath: Interval
-import Optim
+using Optim: Optim, LBFGS, optimize
 using ADTypes: AutoForwardDiff
 
 # An already-transformed mobile is bounded around its current position; the identity rotation
@@ -130,11 +129,11 @@ end
 # at the identity, so a block centered at zero rotation yields a `NaN` gradient and an unbounded
 # line search would stall there. The cap turns that into a harmless no-op while subdivided blocks
 # (nonzero rotation centers) still refine.
-function thick_localsearch(func, box; autodiff = AutoForwardDiff(), maxevals = 100, inner_optimizer = Optim.LBFGS(), kwargs...)
+function thick_localsearch(func, box; autodiff = AutoForwardDiff(), maxevals = 100, inner_optimizer = LBFGS(), kwargs...)
     initial_x = collect(mid(box))
     options = Optim.Options(; f_calls_limit = maxevals, iterations = maxevals, kwargs...)
-    results = Optim.optimize(func, initial_x, inner_optimizer, options; autodiff)
-    return Optim.minimum(results), Optim.minimizer(results), results.f_calls
+    results = optimize(func, initial_x, inner_optimizer, options; autodiff)
+    return results.minimum, results.minimizer, results.f_calls
 end
 
 ## Result translation
@@ -152,14 +151,14 @@ function thick_terminated_by(res, atol, rtol)
     return "terminated early"
 end
 
-# Translate a `ThickSearchResult` into a `GlobalAlignmentResult` for the mobile occupying the
-# `params` coordinates of the flat minimizer. `GlobalAlignmentResult` cannot embed the
-# `ThickSearchResult` — ThickGlobalOptimization is a weak dependency. `stagnant_splits` is `0`:
-# `thicksearch` exposes no since-last-improvement count.
 # Unexplored regions left in the scheduler. `thicksearch`'s default `ConvexHullScheduler` keeps
 # them in a `.structure` hull; other schedulers expose no generic count, so fall back to 0.
 remaining_blocks(scheduler) = hasproperty(scheduler, :structure) ? length(scheduler.structure) : 0
 
+# Translate a `ThickSearchResult` into a `GlobalAlignmentResult` for the mobile occupying the
+# `params` coordinates of the flat minimizer. `GlobalAlignmentResult` cannot embed the
+# `ThickSearchResult` — ThickGlobalOptimization is a weak dependency. `stagnant_splits` is `0`:
+# `thicksearch` exposes no since-last-improvement count.
 function alignment_result(res, x::AbstractModel, y::AbstractModel, params::UnitRange, terminated_by)
     p = Tuple(res.bestminimizer[params])
     progress = [(c, v, Tuple(m[params])) for (c, m, v) in res.progress]
@@ -171,7 +170,8 @@ end
 
 ## Drivers
 
-function globalalign(fixed::AbstractModel, mobiles::AbstractVector{<:AbstractModel};
+function globalalign(
+        fixed::AbstractModel, mobiles::AbstractVector{<:AbstractModel};
         searchspace = nothing, blockfun = UncertaintyRegion, boxsplitter = bisect_largest_rigid,
         objfun, boundsfun, kwargs...
     )

--- a/src/GaussianMixtureAlignment.jl
+++ b/src/GaussianMixtureAlignment.jl
@@ -34,6 +34,42 @@ export rocs_align
 export PointSet, MultiPointSet
 export kabsch, goicp_align, goih_align, tiv_goicp_align, tiv_goih_align
 
+# Global alignment via the ThickGlobalOptimization backend. The methods live in the
+# `GaussianMixtureAlignmentThickExt` extension; loading `ThickGlobalOptimization` brings them
+# into existence. Until then these fallbacks report what is missing rather than a bare
+# `MethodError`.
+"""
+    thick_gogma_align(fixed::AbstractGMM, mobile::AbstractGMM; kwargs...) -> GlobalAlignmentResult
+    thick_gogma_align(fixed::AbstractGMM, mobiles::AbstractVector{<:AbstractGMM}; kwargs...) -> Vector{GlobalAlignmentResult}
+
+Globally align one or more `mobile` GMMs onto a `fixed` GMM by branch-and-bound minimization of
+the negated L2 overlap, using the ThickGlobalOptimization backend. A vector of mobiles is aligned
+simultaneously — each to `fixed` and to the others — returning one `GlobalAlignmentResult` per
+mobile, all sharing the joint objective bounds.
+
+Requires the ThickGlobalOptimization extension; run `using ThickGlobalOptimization`.
+"""
+function thick_gogma_align end
+thick_gogma_align(args...; kwargs...) = error(
+    "`thick_gogma_align` requires the ThickGlobalOptimization extension; run `using ThickGlobalOptimization`"
+)
+
+"""
+    globalalign(fixed::AbstractModel, mobiles::AbstractVector{<:AbstractModel}; kwargs...)
+
+Low-level driver beneath [`thick_gogma_align`](@ref): build the search box over the
+rigid-transformation space spanned by the `mobiles` and run `thicksearch` with the given
+objective and bounds functions.
+
+Requires the ThickGlobalOptimization extension; run `using ThickGlobalOptimization`.
+"""
+function globalalign end
+globalalign(args...; kwargs...) = error(
+    "`globalalign` requires the ThickGlobalOptimization extension; run `using ThickGlobalOptimization`"
+)
+
+export thick_gogma_align
+
 # Semi-public interface: callable and supported, but not brought into the caller's namespace by
 # `using`. `branchbound` and the search-region types are the low-level entry points beneath the
 # `*_align` functions; `icp` and `iterative_hungarian` are correspondence primitives returning
@@ -47,7 +83,7 @@ export kabsch, goicp_align, goih_align, tiv_goicp_align, tiv_goih_align
     eval(
         Expr(
             :public,
-            :branchbound, :UncertaintyRegion, :RotationRegion, :TranslationRegion,
+            :branchbound, :globalalign, :UncertaintyRegion, :RotationRegion, :TranslationRegion,
             :icp, :iterative_hungarian,
             :converged, :tform, :upperbound, :lowerbound, :obj_calls,
             :num_splits, :num_blocks, :stagnant_splits, :progress

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1109,3 +1109,12 @@ end
     @test GMA.icp(xset, yset) isa Vector{<:Tuple{Int, Int}}
     @test GMA.iterative_hungarian(xset, yset) isa Vector{<:Tuple{Int, Int}}
 end
+
+# The ThickGlobalOptimization global-search extension is exercised only when its weak
+# dependencies resolve in the test environment. They are unregistered, so they are not yet
+# part of the test target; the suite skips these tests until they are available.
+if all(p -> Base.identify_package(p) !== nothing, ("ThickGlobalOptimization", "ThickNumbers", "IntervalFastMath"))
+    include("thicksearch.jl")
+else
+    @info "Skipping ThickGlobalOptimization extension tests: weak dependencies not available in the test environment"
+end

--- a/test/thicksearch.jl
+++ b/test/thicksearch.jl
@@ -1,0 +1,97 @@
+# Tests for the GaussianMixtureAlignmentThickExt global-search extension. Reached only when the
+# (currently unregistered) weak dependencies resolve in the test environment; see the guard in
+# runtests.jl.
+
+using Random
+using StaticArrays
+using Rotations
+using ThickGlobalOptimization
+using ThickNumbers
+using IntervalFastMath
+
+const THICK_EXT = Base.get_extension(GaussianMixtureAlignment, :GaussianMixtureAlignmentThickExt)
+
+randgmm(rng, n; σ = 1.0, ϕ = 1.0) =
+    IsotropicGMM([IsotropicGaussian(SVector{3}(randn(rng, 3)...), σ, ϕ) for _ in 1:n])
+
+@testset "thick_gogma_align matches gogma_align" begin
+    # The extension bounds reuse core `gauss_l2_bounds`, so for a single pair the certified
+    # optimum must equal `gogma_align`'s. `thick_gogma_align(fixed, mobile)` aligns `mobile`
+    # onto `fixed`, mirroring `gogma_align(moving, fixed)`.
+    for seed in 1:5
+        rng = MersenneTwister(seed)
+        x = randgmm(rng, 4)
+        y = randgmm(rng, 4)
+        gres = gogma_align(x, y; maxsplits = 1.0e3)
+        tres = thick_gogma_align(y, x; maxsplits = 1000)
+        @test tres isa GMA.GlobalAlignmentResult
+        @test tres.upperbound ≈ gres.upperbound atol = 1.0e-8
+    end
+end
+
+@testset "searchbox / UncertaintyRegion round-trip" begin
+    sr = UncertaintyRegion(RotationVec(0.3, -0.2, 0.5), SVector{3}(1.0, -2.0, 3.0), 0.4, 1.5)
+    box = THICK_EXT.searchbox(sr)
+
+    # A `SearchBox` carries six intervals: three rotation-vector components then three
+    # translation components, each centered on the region with the matching half-width.
+    @test wid(box[1]) / 2 ≈ sr.σᵣ
+    @test wid(box[4]) / 2 ≈ sr.σₜ
+
+    sr2 = UncertaintyRegion(box)
+    @test SVector(sr2.R.sx, sr2.R.sy, sr2.R.sz) ≈ SVector(sr.R.sx, sr.R.sy, sr.R.sz)
+    @test sr2.T ≈ sr.T
+    @test sr2.σᵣ ≈ sr.σᵣ
+    @test sr2.σₜ ≈ sr.σₜ
+
+    # A vector of regions stacks into one 6N-dimensional box; `blockregion(box, i)` recovers
+    # the i-th (zero-based) region.
+    srs = [sr, UncertaintyRegion(RotationVec(0.1, 0.0, -0.1), SVector{3}(0.0, 1.0, 0.0), 0.2, 0.9)]
+    vbox = THICK_EXT.searchbox(srs)
+    for (i, s) in enumerate(srs)
+        b = THICK_EXT.blockregion(vbox, i - 1)
+        @test b.σᵣ ≈ s.σᵣ
+        @test b.σₜ ≈ s.σₜ
+        @test b.T ≈ s.T
+    end
+end
+
+@testset "thick_gogma_align vector path" begin
+    rng = MersenneTwister(11)
+    x = randgmm(rng, 4)
+    y = randgmm(rng, 4)
+
+    # A single-element vector reproduces the scalar method exactly.
+    scalar = thick_gogma_align(y, x; maxsplits = 1000)
+    vec = thick_gogma_align(y, [x]; maxsplits = 1000)
+    @test vec isa Vector{<:GMA.GlobalAlignmentResult}
+    @test length(vec) == 1
+    @test only(vec).upperbound ≈ scalar.upperbound
+
+    # Two mobiles, each a known rigid transform of the fixed GMM, align back onto it: the
+    # recovered overlap approaches the self-overlap ideal.
+    x1 = RotationVec(0.5, 0.2, -0.3) * y + SVector{3}(1.0, 0.0, 2.0)
+    x2 = RotationVec(-0.4, 0.1, 0.6) * y + SVector{3}(-1.0, 1.0, 0.0)
+    res = thick_gogma_align(y, [x1, x2]; maxsplits = 4000)
+    @test length(res) == 2
+    ideal = -overlap(y, y)
+    for (xi, r) in zip((x1, x2), res)
+        @test r isa GMA.GlobalAlignmentResult
+        aligned = r.tform(xi)
+        @test -overlap(aligned, y) ≤ 0.9 * ideal      # captured most of the available overlap
+    end
+end
+
+@testset "AlignmentResults accessors on thick results" begin
+    rng = MersenneTwister(3)
+    x = randgmm(rng, 3)
+    y = randgmm(rng, 3)
+    r = thick_gogma_align(y, x; maxsplits = 1000)
+    @test GMA.tform(r) === r.tform
+    @test GMA.upperbound(r) ≤ 0
+    @test GMA.lowerbound(r) ≤ GMA.upperbound(r)
+    @test GMA.num_splits(r) ≥ 0
+    @test GMA.num_blocks(r) ≥ 0
+    @test GMA.obj_calls(r) ≥ 0
+    @test sprint(show, r) isa String
+end


### PR DESCRIPTION
This adds an extension to make use of the Moore-Skelboe implementation in `ThickGlobalOptimization.jl`. This PR should wait to be merged until IntervalFastMath is public or another ThickNumbers implementation is available. 