### PR TITLE
Add stacked GMMs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GaussianMixtureAlignment"
 uuid = "f2431ed1-b9c2-4fdb-af1b-a74d6c93b3b3"
-version = "0.5.3"
+version = "0.6.0"
 authors = ["Tom McGrath <tmcgrath325@gmail.com> and contributors"]
 
 [deps]

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.12.4"
+julia_version = "1.12.6"
 manifest_format = "2.0"
 project_hash = "2bd4be6dbdaba3b49ed380afb27570c097ef3849"
 
@@ -282,10 +282,10 @@ uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 version = "1.11.0"
 
 [[deps.GaussianMixtureAlignment]]
-deps = ["ADTypes", "CoordinateTransformations", "Distances", "GenericLinearAlgebra", "Hungarian", "LinearAlgebra", "MutableConvexHulls", "NearestNeighbors", "Optim", "PairedLinkedLists", "Requires", "Rotations", "StaticArrays"]
+deps = ["ADTypes", "CoordinateTransformations", "Distances", "GenericLinearAlgebra", "Hungarian", "LinearAlgebra", "MutableConvexHulls", "NearestNeighbors", "Optim", "PairedLinkedLists", "Rotations", "StaticArrays"]
 path = ".."
 uuid = "f2431ed1-b9c2-4fdb-af1b-a74d6c93b3b3"
-version = "0.5.0"
+version = "0.6.0"
 
     [deps.GaussianMixtureAlignment.extensions]
     GaussianMixtureAlignmentMakieExt = ["Colors", "GeometryBasics", "Makie"]
@@ -605,12 +605,6 @@ deps = ["LazilyInitializedFields", "Pkg", "TOML", "Tar"]
 git-tree-sha1 = "ffd19052caf598b8653b99404058fce14828be51"
 uuid = "2792f1a3-b283-48e8-9a74-f99dce5104f3"
 version = "0.1.0"
-
-[[deps.Requires]]
-deps = ["UUIDs"]
-git-tree-sha1 = "62389eeff14780bfe55195b7204c0d8738436d64"
-uuid = "ae029012-a4dd-5104-9daa-d747884805df"
-version = "1.3.1"
 
 [[deps.Rotations]]
 deps = ["LinearAlgebra", "Quaternions", "Random", "StaticArrays"]

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -24,6 +24,9 @@ IsotropicGaussian
 IsotropicGMM
 IsotropicMultiGMM
 LabeledIsotropicGMM
+StackedLabeledGaussian
+StackedLabeledIsotropicGMM
+stackedgmm
 ```
 
 ### Point set types

--- a/src/GaussianMixtureAlignment.jl
+++ b/src/GaussianMixtureAlignment.jl
@@ -25,10 +25,11 @@ using NearestNeighbors: NearestNeighbors, Euclidean, KDTree, nn
 using Optim: Optim, Fminbox, LBFGS, optimize
 using PairedLinkedLists: PairedLinkedLists, ListNodeIterator, deletenode!, getnode, target
 using Rotations: Rotations, AngleAxis, RotationVec
-using StaticArrays: StaticArrays, SMatrix, SVector
+using StaticArrays: StaticArrays, MVector, SMatrix, SVector
 
 export AbstractGaussian, AbstractGMM
 export IsotropicGaussian, IsotropicGMM, LabeledIsotropicGMM, IsotropicMultiGMM
+export StackedLabeledGaussian, StackedLabeledIsotropicGMM, stackedgmm
 export overlap, force!, force, gogma_align, rot_gogma_align, trl_gogma_align, tiv_gogma_align
 export rocs_align
 export PointSet, MultiPointSet

--- a/src/gogma/bounds.jl
+++ b/src/gogma/bounds.jl
@@ -21,6 +21,12 @@ inputs the results are dense matrices indexed by Gaussian; for `AbstractMultiGMM
 are nested dictionaries keyed by component label, with `interactions` weighting the
 cross-label terms.
 
+For `AbstractStackedLabeledIsotropicGMM` inputs the matrices hold one `SVector{Lx*Ly}` per
+pair of stacked points — one combined variance and one weight per pairing of feature slots —
+consumed termwise by the multi-term `overlap` and `gauss_l2_bounds` kernels at the single
+distance between the shared means (the same layout `tiv_pairwise_consts` uses for the head
+and tail terms of a TIV pair).
+
 These constants depend only on the Gaussians' widths and amplitudes, not on the relative
 transformation, so they are invariant under the rigid search. They are the per-pair inputs to
 `gauss_l2_bounds` and `local_align`. The `*_align` entry points call `pairwise_consts` once and
@@ -96,6 +102,122 @@ function pairwise_consts(gmmx::AbstractLabeledIsotropicGMM{N, T, K}, gmmy::Abstr
         end
     end
     return pσ, pϕ
+end
+
+# For stacked GMMs, a pair's overlap is the sum of one term per pairing of feature slots,
+# all sharing the mean pair's single distance: entry `m` of `pσ[i,j]`/`pϕ[i,j]` holds the
+# combined variance and weight of slot pair `(k, l) = fldmod1(m, Ly)`. Zero-amplitude
+# (padded) and non-interacting slot pairs get zero weight and are skipped by the multi-term
+# `overlap` and `gauss_l2_bounds` kernels.
+function pairwise_consts(
+        gmmx::AbstractStackedLabeledIsotropicGMM{N, T, Lx, K}, gmmy::AbstractStackedLabeledIsotropicGMM{N, S, Ly, K},
+        interactions::Nothing = nothing
+    ) where {N, T, S, Lx, Ly, K}
+    t = promote_type(T, S)
+    xlabels = unique!([l for g in gmmx.gaussians for l in g.labels])
+    ylabels = unique!([l for g in gmmy.gaussians for l in g.labels])
+    self_interactions = Dict{Tuple{K, K}, t}()
+    for label in xlabels ∩ ylabels
+        self_interactions[(label, label)] = one(t)
+    end
+    return pairwise_consts(gmmx, gmmy, self_interactions)
+end
+
+function pairwise_consts(
+        gmmx::AbstractStackedLabeledIsotropicGMM{N, T, Lx, K}, gmmy::AbstractStackedLabeledIsotropicGMM{N, S, Ly, K},
+        interactions::Dict{Tuple{K, K}, V}
+    ) where {N, T, S, Lx, Ly, K, V <: Number}
+    validate_interactions(interactions) || throw(ArgumentError("Interactions must not include redundant key pairs (i.e. (k1,k2) and (k2,k1))"))
+    t = promote_type(T, S, V)
+    gxs, gys = gmmx.gaussians, gmmy.gaussians
+    Base.require_one_based_indexing(gxs, gys)
+
+    # as in the labeled method: each label pair's coefficient is resolved once into `coefs`
+    # and thereafter indexed, rather than hashed again for every slot pair
+    uxs = unique!([l for g in gxs for l in g.labels])
+    uys = unique!([l for g in gys for l in g.labels])
+    coefs = t[interaction_coefficient(interactions, kx, ky) for kx in uxs, ky in uys]
+    ix = [map(l -> findfirst(isequal(l), uxs)::Int, g.labels) for g in gxs]
+    iy = [map(l -> findfirst(isequal(l), uys)::Int, g.labels) for g in gys]
+
+    P = Lx * Ly
+    pσ = Matrix{SVector{P, t}}(undef, length(gmmx), length(gmmy))
+    pϕ = Matrix{SVector{P, t}}(undef, length(gmmx), length(gmmy))
+    for i in eachindex(gxs)
+        gx, cx = gxs[i], ix[i]
+        for j in eachindex(gys)
+            gy, cy = gys[j], iy[j]
+            pσ[i, j] = SVector{P, t}(
+                ntuple(Val(P)) do m
+                    k, l = fldmod1(m, Ly)
+                    gx.σ[k]^2 + gy.σ[l]^2
+                end
+            )
+            pϕ[i, j] = SVector{P, t}(
+                ntuple(Val(P)) do m
+                    k, l = fldmod1(m, Ly)
+                    coefs[cx[k], cy[l]] * gx.ϕ[k] * gy.ϕ[l]
+                end
+            )
+        end
+    end
+    return pσ, pϕ
+end
+
+# a labeled GMM is a stacked GMM with one feature per point, so mixed alignments lift the
+# labeled side; both Nothing and Dict methods are needed to stay more specific than the
+# generic `(AbstractIsotropicGMM, AbstractIsotropicGMM, Nothing)` method in every argument
+pairwise_consts(gmmx::AbstractStackedLabeledIsotropicGMM{N, T, L, K}, gmmy::AbstractLabeledIsotropicGMM{N, S, K}, interactions::Nothing = nothing) where {N, T, L, K, S} =
+    pairwise_consts(gmmx, StackedLabeledIsotropicGMM(gmmy), interactions)
+pairwise_consts(gmmx::AbstractStackedLabeledIsotropicGMM{N, T, L, K}, gmmy::AbstractLabeledIsotropicGMM{N, S, K}, interactions::Dict{Tuple{K, K}, V}) where {N, T, L, K, S, V <: Number} =
+    pairwise_consts(gmmx, StackedLabeledIsotropicGMM(gmmy), interactions)
+pairwise_consts(gmmx::AbstractLabeledIsotropicGMM{N, T, K}, gmmy::AbstractStackedLabeledIsotropicGMM{N, S, L, K}, interactions::Nothing = nothing) where {N, T, K, S, L} =
+    pairwise_consts(StackedLabeledIsotropicGMM(gmmx), gmmy, interactions)
+pairwise_consts(gmmx::AbstractLabeledIsotropicGMM{N, T, K}, gmmy::AbstractStackedLabeledIsotropicGMM{N, S, L, K}, interactions::Dict{Tuple{K, K}, V}) where {N, T, K, S, L, V <: Number} =
+    pairwise_consts(StackedLabeledIsotropicGMM(gmmx), gmmy, interactions)
+
+const STACKED_UNLABELED_ERROR = "cannot pair a stacked labeled GMM with an unlabeled IsotropicGMM; wrap the IsotropicGMM in a LabeledIsotropicGMM first"
+pairwise_consts(gmmx::AbstractStackedLabeledIsotropicGMM, gmmy::IsotropicGMM, interactions::Nothing = nothing) = throw(ArgumentError(STACKED_UNLABELED_ERROR))
+pairwise_consts(gmmx::AbstractStackedLabeledIsotropicGMM, gmmy::IsotropicGMM, interactions::Dict) = throw(ArgumentError(STACKED_UNLABELED_ERROR))
+pairwise_consts(gmmx::IsotropicGMM, gmmy::AbstractStackedLabeledIsotropicGMM, interactions::Nothing = nothing) = throw(ArgumentError(STACKED_UNLABELED_ERROR))
+pairwise_consts(gmmx::IsotropicGMM, gmmy::AbstractStackedLabeledIsotropicGMM, interactions::Dict) = throw(ArgumentError(STACKED_UNLABELED_ERROR))
+
+# single-pair form of the stacked constants, for direct Gaussian-pair `overlap` calls
+function stacked_pair_consts(x::StackedLabeledGaussian{N, T, Lx, K}, y::StackedLabeledGaussian{N, S, Ly, K}, interactions::Nothing = nothing) where {N, T, Lx, K, S, Ly}
+    t = promote_type(T, S)
+    P = Lx * Ly
+    s = SVector{P, t}(
+        ntuple(Val(P)) do m
+            k, l = fldmod1(m, Ly)
+            x.σ[k]^2 + y.σ[l]^2
+        end
+    )
+    w = SVector{P, t}(
+        ntuple(Val(P)) do m
+            k, l = fldmod1(m, Ly)
+            x.labels[k] == y.labels[l] ? x.ϕ[k] * y.ϕ[l] : zero(t)
+        end
+    )
+    return s, w
+end
+
+function stacked_pair_consts(x::StackedLabeledGaussian{N, T, Lx, K}, y::StackedLabeledGaussian{N, S, Ly, K}, interactions::Dict{Tuple{K, K}, V}) where {N, T, Lx, K, S, Ly, V <: Number}
+    validate_interactions(interactions) || throw(ArgumentError("Interactions must not include redundant key pairs (i.e. (k1,k2) and (k2,k1))"))
+    t = promote_type(T, S, V)
+    P = Lx * Ly
+    s = SVector{P, t}(
+        ntuple(Val(P)) do m
+            k, l = fldmod1(m, Ly)
+            x.σ[k]^2 + y.σ[l]^2
+        end
+    )
+    w = SVector{P, t}(
+        ntuple(Val(P)) do m
+            k, l = fldmod1(m, Ly)
+            interaction_coefficient(interactions, x.labels[k], y.labels[l]) * x.ϕ[k] * y.ϕ[l]
+        end
+    )
+    return s, w
 end
 
 function pairwise_consts(mgmmx::AbstractMultiGMM{N, T, K}, mgmmy::AbstractMultiGMM{N, S, K}, interactions::Nothing = nothing) where {N, T, S, K}

--- a/src/gogma/gmm.jl
+++ b/src/gogma/gmm.jl
@@ -69,7 +69,7 @@ empty!(gmm::AbstractSingleGMM) = empty!(gmm.gaussians)
 
 coords(gmm::AbstractSingleGMM) = reduce(hcat, [g.μ for g in gmm.gaussians])
 weights(gmm::AbstractSingleGMM) = [g.ϕ for g in gmm.gaussians]
-widths(gmm::AbstractSingleGMM) = [g.ϕ for g in gmm.gaussians]
+widths(gmm::AbstractSingleGMM) = [g.σ for g in gmm.gaussians]
 
 length(mgmm::AbstractMultiGMM) = length(mgmm.gmms)
 getindex(mgmm::AbstractMultiGMM, k) = mgmm.gmms[k]

--- a/src/gogma/gmm.jl
+++ b/src/gogma/gmm.jl
@@ -38,6 +38,15 @@ abstract type AbstractLabeledIsotropicGMM{N, T, K} <: AbstractIsotropicGMM{N, T}
 # concrete subtypes:
 #   LabeledIsotropicGMM
 
+"""
+Abstract base type for single isotropic GMMs whose Gaussians each stack `L` labeled features
+on a shared mean, with slot-wise widths, amplitudes, and labels (see
+`StackedLabeledGaussian`). Concrete implementation: `StackedLabeledIsotropicGMM`.
+"""
+abstract type AbstractStackedLabeledIsotropicGMM{N, T, L, K} <: AbstractIsotropicGMM{N, T} end
+# concrete subtypes:
+#   StackedLabeledIsotropicGMM
+
 abstract type AbstractMultiGMM{N, T, K} <: AbstractGMM{N, T} end
 abstract type AbstractIsotropicMultiGMM{N, T, K} <: AbstractMultiGMM{N, T, K} end
 # concrete subtypes:
@@ -209,6 +218,211 @@ end
 eltype(::Type{TIVGMM{N, T, K}}) where {N, T, K} = IsotropicGaussian{N, T}
 
 """
+    StackedLabeledGaussian(μ, σ, ϕ, labels)
+
+`L` isotropic Gaussian features stacked on a single point: one mean `μ` shared by all slots,
+with slot-wise widths `σ`, amplitudes `ϕ`, and labels stored as length-`L` `SVector`s. Slot
+`k` represents an isotropic Gaussian with mean `μ`, width `σ[k]`, amplitude `ϕ[k]`, and
+label `labels[k]`.
+
+Slots with `ϕ = 0` contribute nothing to overlaps, so a point with fewer than `L` features
+is padded with amplitude-zero slots. A padded slot's width is arbitrary but must be positive
+(conventionally `σ = 1`), and its label may repeat any valid label.
+"""
+struct StackedLabeledGaussian{N, T, L, K} <: AbstractIsotropicGaussian{N, T}
+    μ::SVector{N, T}
+    σ::SVector{L, T}
+    ϕ::SVector{L, T}
+    labels::SVector{L, K}
+    function StackedLabeledGaussian{N, T, L, K}(μ, σ, ϕ, labels) where {N, T, L, K}
+        g = new{N, T, L, K}(μ, σ, ϕ, labels)
+        all(>(0), g.σ) || throw(ArgumentError("all slot widths must be positive, including padded slots (pad with σ = 1, ϕ = 0); got σ = $(g.σ)"))
+        return g
+    end
+end
+
+function StackedLabeledGaussian(μ::AbstractVector, σ::AbstractVector, ϕ::AbstractVector, labels::AbstractVector)
+    length(σ) == length(ϕ) == length(labels) ||
+        throw(DimensionMismatch("σ, ϕ, and labels must have equal lengths; got $(length(σ)), $(length(ϕ)), and $(length(labels))"))
+    t = promote_type(eltype(μ), eltype(σ), eltype(ϕ))
+    return StackedLabeledGaussian{length(μ), t, length(σ), eltype(labels)}(μ, σ, ϕ, labels)
+end
+
+StackedLabeledGaussian(g::StackedLabeledGaussian) = StackedLabeledGaussian(g.μ, g.σ, g.ϕ, g.labels)
+StackedLabeledGaussian(g::AbstractIsotropicGaussian, label) =
+    StackedLabeledGaussian(g.μ, SVector(g.σ), SVector(g.ϕ), SVector(label))
+
+convert(::Type{StackedLabeledGaussian{N, T, L, K}}, g::StackedLabeledGaussian) where {N, T, L, K} =
+    StackedLabeledGaussian{N, T, L, K}(g.μ, g.σ, g.ϕ, g.labels)
+promote_rule(::Type{StackedLabeledGaussian{N, T, L, K}}, ::Type{StackedLabeledGaussian{N, S, L, K}}) where {N, T, S, L, K} =
+    StackedLabeledGaussian{N, promote_type(T, S), L, K}
+
+function (g::StackedLabeledGaussian)(pos::AbstractVector)
+    distsq = sum(abs2, pos - g.μ)
+    return sum(g.ϕ[k] * exp(-distsq / (2 * g.σ[k]^2)) for k in eachindex(g.σ, g.ϕ))
+end
+
+"""
+    StackedLabeledIsotropicGMM(gaussians)
+    StackedLabeledIsotropicGMM(μs, σs, ϕs, labelss; padσ = 1)
+    StackedLabeledIsotropicGMM(gmm::AbstractLabeledIsotropicGMM)
+
+Gaussian Mixture Model in `N` dimensions whose components are
+`StackedLabeledGaussian{N,T,L,K}`s, each stacking `L` labeled features on a single mean.
+The stacking degree `L` is uniform across the model — enforced by the concrete element type
+— which keeps the pairwise constants type-stable; points with fewer features are padded with
+amplitude-zero slots.
+
+Compared to a `LabeledIsotropicGMM` that repeats a mean once per feature, aligning stacked
+models computes distances and distance bounds once per pair of means rather than once per
+pair of features, while producing identical overlaps and bounds (see [`stackedgmm`](@ref)).
+
+The four-vector form builds the model from per-point feature data: point `i` has mean
+`μs[i]` and features with widths `σs[i]`, amplitudes `ϕs[i]`, and labels `labelss[i]`. `L`
+is the maximum feature count; points with fewer features are padded with amplitude-zero
+slots of width `padσ`, repeating the point's first label. Every point must have at least one
+feature.
+
+Constructing from an `AbstractLabeledIsotropicGMM` lifts each labeled Gaussian to a
+single-slot (`L = 1`) stacked Gaussian without any grouping of equal means.
+"""
+struct StackedLabeledIsotropicGMM{N, T, L, K} <: AbstractStackedLabeledIsotropicGMM{N, T, L, K}
+    gaussians::Vector{StackedLabeledGaussian{N, T, L, K}}
+end
+
+StackedLabeledIsotropicGMM(gmm::AbstractStackedLabeledIsotropicGMM) = StackedLabeledIsotropicGMM(gmm.gaussians)
+StackedLabeledIsotropicGMM{N, T, L, K}() where {N, T, L, K} = StackedLabeledIsotropicGMM{N, T, L, K}(StackedLabeledGaussian{N, T, L, K}[])
+
+function StackedLabeledIsotropicGMM(gmm::AbstractLabeledIsotropicGMM{N, T, K}) where {N, T, K}
+    gaussians = [
+        StackedLabeledGaussian{N, T, 1, K}(g.μ, SVector(g.σ), SVector(g.ϕ), SVector(l))
+            for (g, l) in zip(gmm.gaussians, gmm.labels)
+    ]
+    return StackedLabeledIsotropicGMM{N, T, 1, K}(gaussians)
+end
+
+function StackedLabeledIsotropicGMM(μs::AbstractVector, σs::AbstractVector, ϕs::AbstractVector, labelss::AbstractVector; padσ = 1)
+    axes(μs) == axes(σs) == axes(ϕs) == axes(labelss) ||
+        throw(DimensionMismatch("μs, σs, ϕs, and labelss must share axes; got $(axes(μs)), $(axes(σs)), $(axes(ϕs)), and $(axes(labelss))"))
+    isempty(μs) && throw(ArgumentError("at least one point is required"))
+    for i in eachindex(σs, ϕs, labelss)
+        length(σs[i]) == length(ϕs[i]) == length(labelss[i]) ||
+            throw(DimensionMismatch("point $i has mismatched feature counts: $(length(σs[i])) widths, $(length(ϕs[i])) amplitudes, and $(length(labelss[i])) labels"))
+        isempty(σs[i]) && throw(ArgumentError("point $i has no features; every point needs at least one to supply a label for padded slots"))
+    end
+    N = length(first(μs))
+    T = promote_type(
+        mapreduce(eltype, promote_type, μs), mapreduce(eltype, promote_type, σs),
+        mapreduce(eltype, promote_type, ϕs), typeof(padσ)
+    )
+    K = mapreduce(eltype, promote_type, labelss)
+    L = maximum(length, σs)
+    gaussians = map(eachindex(μs, σs, ϕs, labelss)) do i
+        npad = L - length(σs[i])
+        σ = [σs[i]; fill(padσ, npad)]
+        ϕ = [ϕs[i]; zeros(npad)]
+        labels = [labelss[i]; fill(first(labelss[i]), npad)]
+        StackedLabeledGaussian{N, T, L, K}(μs[i], σ, ϕ, labels)
+    end
+    return StackedLabeledIsotropicGMM{N, T, L, K}(gaussians)
+end
+
+convert(::Type{GMM}, gmm::AbstractStackedLabeledIsotropicGMM) where {GMM <: StackedLabeledIsotropicGMM} = GMM(gmm.gaussians)
+promote_rule(::Type{StackedLabeledIsotropicGMM{N, T, L, K}}, ::Type{StackedLabeledIsotropicGMM{N, S, L, K}}) where {N, T, S, L, K} =
+    StackedLabeledIsotropicGMM{N, promote_type(T, S), L, K}
+eltype(::Type{StackedLabeledIsotropicGMM{N, T, L, K}}) where {N, T, L, K} = StackedLabeledGaussian{N, T, L, K}
+
+(gmm::StackedLabeledIsotropicGMM)(pos::AbstractVector) = sum(g(pos) for g in gmm)
+
+weights(gmm::AbstractStackedLabeledIsotropicGMM) = [sum(g.ϕ) for g in gmm.gaussians]
+# amplitude-weighted RMS width: reproduces the stack's total second moment Σₖ ϕₖσₖ² in the
+# `weights .* widths .^ 2` products consumed by `inertial_transforms`
+function widths(gmm::AbstractStackedLabeledIsotropicGMM{N, T}) where {N, T}
+    z = zero(sqrt(one(T)))
+    return map(gmm.gaussians) do g
+        ϕtot = sum(g.ϕ)
+        iszero(ϕtot) ? z : sqrt(sum(g.ϕ .* g.σ .^ 2) / ϕtot)
+    end
+end
+
+"""
+    sgmm = stackedgmm(gmm::AbstractLabeledIsotropicGMM)
+
+Convert a labeled GMM to a [`StackedLabeledIsotropicGMM`](@ref) by grouping Gaussians with
+exactly equal means into stacked components. The stacking degree is the largest group size;
+smaller groups are padded with amplitude-zero slots. Groups are ordered by first appearance,
+and features within a group keep their order in `gmm`.
+
+The result's stacking degree depends on run-time values, so this function is not type
+stable; the `*_align` entry points act as function barriers, so this does not affect
+alignment performance.
+"""
+function stackedgmm(gmm::AbstractLabeledIsotropicGMM{N, T, K}) where {N, T, K}
+    idxof = Dict{SVector{N, T}, Int}()
+    groups = Vector{Int}[]
+    for i in eachindex(gmm.gaussians)
+        gi = get!(idxof, gmm.gaussians[i].μ) do
+            push!(groups, Int[])
+            length(groups)
+        end
+        push!(groups[gi], i)
+    end
+    μs = [gmm.gaussians[first(group)].μ for group in groups]
+    σs = [[gmm.gaussians[i].σ for i in group] for group in groups]
+    ϕs = [[gmm.gaussians[i].ϕ for i in group] for group in groups]
+    labelss = [[gmm.labels[i] for i in group] for group in groups]
+    return StackedLabeledIsotropicGMM(μs, σs, ϕs, labelss; padσ = one(T))
+end
+
+"""
+    StackedTIVGMM(gaussians, headσ, headϕ, headlabels, tailσ, tailϕ, taillabels)
+
+Translation-invariant-vector model built from a `StackedLabeledIsotropicGMM` by
+[`tivgmm`](@ref). Each Gaussian's mean is the difference vector between two stacked points
+of the source model; the slot-wise widths, amplitudes, and labels of both endpoint stacks
+are kept in the parallel `head*`/`tail*` vectors so that a TIV pair can be scored as the sum
+of head-head and tail-tail feature overlaps over all pairings of endpoint slots (see
+`tiv_pairwise_consts`). Endpoint positions are not stored: they are not translation
+invariant, so they would go stale under the rigid transformations applied during rotational
+search.
+
+The `σ` and `ϕ` stored on the Gaussians themselves are geometric means of aggregate endpoint
+values (total amplitude and amplitude-weighted RMS width), used only where a TIV must be
+treated as a single unlabeled feature.
+"""
+struct StackedTIVGMM{N, T, L, K} <: AbstractIsotropicGMM{N, T}
+    gaussians::Vector{IsotropicGaussian{N, T}}
+    headσ::Vector{SVector{L, T}}
+    headϕ::Vector{SVector{L, T}}
+    headlabels::Vector{SVector{L, K}}
+    tailσ::Vector{SVector{L, T}}
+    tailϕ::Vector{SVector{L, T}}
+    taillabels::Vector{SVector{L, K}}
+    function StackedTIVGMM{N, T, L, K}(gaussians, headσ, headϕ, headlabels, tailσ, tailϕ, taillabels) where {N, T, L, K}
+        n = length(gaussians)
+        for v in (headσ, headϕ, headlabels, tailσ, tailϕ, taillabels)
+            length(v) == n ||
+                throw(DimensionMismatch("each endpoint vector must match the number of Gaussians ($n); got length $(length(v))"))
+        end
+        return new{N, T, L, K}(gaussians, headσ, headϕ, headlabels, tailσ, tailϕ, taillabels)
+    end
+end
+
+function StackedTIVGMM(
+        gaussians::AbstractVector{IsotropicGaussian{N, T}}, headσ, headϕ, headlabels::AbstractVector{SVector{L, K}},
+        tailσ, tailϕ, taillabels::AbstractVector{SVector{L, K}}
+    ) where {N, T, L, K}
+    return StackedTIVGMM{N, T, L, K}(gaussians, headσ, headϕ, headlabels, tailσ, tailϕ, taillabels)
+end
+
+StackedTIVGMM(tiv::TIVGMM{N, T, K}) where {N, T, K} = StackedTIVGMM{N, T, 1, K}(
+    tiv.gaussians, SVector.(tiv.headσ), SVector.(tiv.headϕ), SVector.(tiv.headlabels),
+    SVector.(tiv.tailσ), SVector.(tiv.tailϕ), SVector.(tiv.taillabels)
+)
+
+eltype(::Type{StackedTIVGMM{N, T, L, K}}) where {N, T, L, K} = IsotropicGaussian{N, T}
+
+"""
     IsotropicMultiGMM(gmms)
 
 A keyed collection of `IsotropicGMM`s, each considered separately during alignment.
@@ -233,6 +447,12 @@ Base.show(io::IO, g::AbstractIsotropicGaussian) = println(
     summary(g),
     " with μ = $(g.μ), σ = $(g.σ), and ϕ = $(g.ϕ).\n"
 
+)
+
+Base.show(io::IO, g::StackedLabeledGaussian) = println(
+    io,
+    summary(g),
+    " with μ = $(g.μ), σ = $(g.σ), ϕ = $(g.ϕ), and labels = $(g.labels).\n"
 )
 
 Base.show(io::IO, gmm::AbstractSingleGMM) = println(

--- a/src/gogma/overlap.jl
+++ b/src/gogma/overlap.jl
@@ -96,6 +96,32 @@ function overlap(x::AbstractLabeledIsotropicGMM, y::AbstractLabeledIsotropicGMM;
 end
 
 """
+    ovlp = overlap(x::AbstractStackedLabeledIsotropicGMM, y::AbstractStackedLabeledIsotropicGMM; interactions=nothing)
+
+Calculate the unnormalized overlap between two stacked labeled GMMs: for each pair of
+stacked points, the sum over all pairings of their feature slots, evaluated at the single
+distance between the shared means. The optional keyword argument `interactions` weights
+slot pairs by label as for `AbstractLabeledIsotropicGMM`; when omitted, only slots with
+equal labels contribute, each with coefficient 1. A labeled GMM may be paired with a stacked
+one; it is lifted to a single-slot stacked model first.
+"""
+function overlap(x::AbstractStackedLabeledIsotropicGMM, y::AbstractStackedLabeledIsotropicGMM; interactions = nothing)
+    pσ, pϕ = pairwise_consts(x, y, interactions)
+    return overlap(x, y, pσ, pϕ)
+end
+overlap(x::AbstractStackedLabeledIsotropicGMM, y::AbstractLabeledIsotropicGMM; interactions = nothing) =
+    overlap(x, StackedLabeledIsotropicGMM(y); interactions)
+overlap(x::AbstractLabeledIsotropicGMM, y::AbstractStackedLabeledIsotropicGMM; interactions = nothing) =
+    overlap(StackedLabeledIsotropicGMM(x), y; interactions)
+
+# Gaussian-pair overlap for stacked Gaussians: the generic method's default `s`/`w`
+# expressions assume scalar σ and ϕ, so the slot-cross constants are built explicitly
+function overlap(x::StackedLabeledGaussian, y::StackedLabeledGaussian; interactions = nothing)
+    s, w = stacked_pair_consts(x, y, interactions)
+    return overlap(sum(abs2, x.μ .- y.μ), s, w)
+end
+
+"""
     ovlp = overlap(x::AbstractMultiGMM, y::AbstractMultiGMM; interactions=nothing)
 
 Calculate the unnormalized overlap between two `AbstractMultiGMM` objects. The optional
@@ -162,6 +188,18 @@ function force!(f::AbstractVector, x::AbstractVector, y::AbstractVector, s::Real
     return f .+= Δ / s * overlap(sum(abs2, Δ), s, w)
 end
 
+# multi-term kernel: sum the per-term forces at a single displacement, skipping zero-weight
+# (padded or non-interacting) terms as the multi-term `overlap` kernel does
+function force!(f::AbstractVector, x::AbstractVector, y::AbstractVector, s::AbstractVector, w::AbstractVector)
+    Δ = y - x
+    distsq = sum(abs2, Δ)
+    for k in eachindex(s, w)
+        iszero(w[k]) && continue
+        f .+= Δ / s[k] * overlap(distsq, s[k], w[k])
+    end
+    return f
+end
+
 function force!(
         f::AbstractVector, x::AbstractIsotropicGaussian, y::AbstractIsotropicGaussian,
         s = x.σ^2 + y.σ^2, w = x.ϕ * y.ϕ; coef = 1
@@ -200,6 +238,21 @@ function force!(f::AbstractVector, x::AbstractLabeledIsotropicGMM, y::AbstractLa
     end
     return
 end
+
+function force!(f::AbstractVector, x::AbstractStackedLabeledIsotropicGMM, y::AbstractStackedLabeledIsotropicGMM, pσ = nothing, pϕ = nothing; interactions = nothing, kwargs...)
+    if isnothing(pσ) && isnothing(pϕ)
+        pσ, pϕ = pairwise_consts(x, y, interactions)
+    end
+    for (i, gx) in enumerate(x.gaussians)
+        force!(f, gx, y, pσ[i, :], pϕ[i, :]; kwargs...)
+    end
+    return
+end
+
+force!(f::AbstractVector, x::AbstractStackedLabeledIsotropicGMM, y::AbstractLabeledIsotropicGMM, pσ = nothing, pϕ = nothing; kwargs...) =
+    force!(f, x, StackedLabeledIsotropicGMM(y), pσ, pϕ; kwargs...)
+force!(f::AbstractVector, x::AbstractLabeledIsotropicGMM, y::AbstractStackedLabeledIsotropicGMM, pσ = nothing, pϕ = nothing; kwargs...) =
+    force!(f, StackedLabeledIsotropicGMM(x), y, pσ, pϕ; kwargs...)
 
 function force!(f::AbstractVector, x::AbstractMultiGMM, y::AbstractMultiGMM; interactions = nothing)
     mpσ, mpϕ = pairwise_consts(x, y, interactions)

--- a/src/gogma/tiv.jl
+++ b/src/gogma/tiv.jl
@@ -77,6 +77,52 @@ function tivgmm(gmm::AbstractLabeledIsotropicGMM{N, T, K}, c = Inf) where {N, T,
     return TIVGMM(tivgaussians, headσ, headϕ, headlabels, tailσ, tailϕ, taillabels)
 end
 
+"""
+    tgmm = tivgmm(gmm::AbstractStackedLabeledIsotropicGMM, c=Inf)
+
+Build TIVs for a stacked labeled GMM, returning a [`StackedTIVGMM`](@ref) that keeps the
+slot-wise widths, amplitudes, and labels of each TIV's two endpoint stacks: the TIV
+connecting stacked point `i` (head) to stacked point `j` (tail) has mean `μᵢ - μⱼ`, head
+slots from point `i`, and tail slots from point `j`.
+
+TIV selection mirrors the labeled method, scoring each candidate by its length times the
+geometric mean of the endpoints' total amplitudes; `c` counts stacked points, so with
+`c = Inf` this yields `n² - n` TIVs for `n` stacked points (zero-length TIVs, `i == j`, are
+excluded as rotation-independent).
+"""
+function tivgmm(gmm::AbstractStackedLabeledIsotropicGMM{N, T, L, K}, c = Inf) where {N, T, L, K}
+    npts = length(gmm)
+    n = Int(min(ceil(c * npts), npts^2 - npts))
+    ϕtot = weights(gmm)
+    σagg = widths(gmm)
+    scores = fill(zero(T), npts, npts)
+    for i in 1:npts
+        for j in i:npts
+            scores[i, j] = scores[j, i] = norm(gmm.gaussians[i].μ - gmm.gaussians[j].μ) * √(ϕtot[i] * ϕtot[j])
+        end
+    end
+
+    tivgaussians = IsotropicGaussian{N, T}[]
+    headσ, headϕ, headlabels = SVector{L, T}[], SVector{L, T}[], SVector{L, K}[]
+    tailσ, tailϕ, taillabels = SVector{L, T}[], SVector{L, T}[], SVector{L, K}[]
+    order = sortperm(vec(scores), rev = true)
+    for idx in order
+        length(tivgaussians) == n && break
+        i = Int(floor((idx - 1) / npts) + 1)
+        j = mod(idx - 1, npts) + 1
+        i == j && continue
+        x, y = gmm.gaussians[i], gmm.gaussians[j]
+        push!(tivgaussians, IsotropicGaussian(x.μ - y.μ, √(σagg[i] * σagg[j]), √(ϕtot[i] * ϕtot[j])))
+        push!(headσ, x.σ)
+        push!(headϕ, x.ϕ)
+        push!(headlabels, x.labels)
+        push!(tailσ, y.σ)
+        push!(tailϕ, y.ϕ)
+        push!(taillabels, y.labels)
+    end
+    return StackedTIVGMM{N, T, L, K}(tivgaussians, headσ, headϕ, headlabels, tailσ, tailϕ, taillabels)
+end
+
 function tivgmm(mgmm::AbstractIsotropicMultiGMM, c = Inf)
     gmms = Dict{Symbol, IsotropicGMM{dims(mgmm), numbertype(mgmm)}}()
     for key in keys(mgmm.gmms)
@@ -156,3 +202,87 @@ function tiv_pairwise_consts(
     end
     return pσ, pϕ
 end
+
+function tiv_pairwise_consts(tivx::StackedTIVGMM{N, T, Lx, K}, tivy::StackedTIVGMM{N, S, Ly, K}, ::Nothing) where {N, T, S, Lx, Ly, K}
+    t = promote_type(T, S)
+    xlabels = unique!([l for ls in Iterators.flatten((tivx.headlabels, tivx.taillabels)) for l in ls])
+    ylabels = unique!([l for ls in Iterators.flatten((tivy.headlabels, tivy.taillabels)) for l in ls])
+    self_interactions = Dict{Tuple{K, K}, t}()
+    for label in xlabels ∩ ylabels
+        self_interactions[(label, label)] = one(t)
+    end
+    return tiv_pairwise_consts(tivx, tivy, self_interactions)
+end
+
+# For a stacked TIV pair, the head/tail variance split of the scalar TIV kernel is applied
+# per pairing of endpoint slots: choosing head slots (a, c) and tail slots (b, d) fixes
+# `s_h = σ_h[a]² + σ_h[c]²`, `s_t = σ_t[b]² + σ_t[d]²`, and `S = s_h + s_t`, contributing a
+# head term of width `S²/s_h` and a tail term of width `S²/s_t`, each weighted by that
+# endpoint slot pair's interaction coefficient and amplitude product. This enumerates
+# `2⋅Lx²⋅Ly²` terms per TIV pair — exactly the terms a mean-duplicated model produces, so
+# stacked and duplicated models give identical TIV overlaps, while the distance bounds are
+# evaluated once per TIV pair instead of once per slot pairing. The per-pair term count
+# grows as `L⁴`, so large stacking degrees are expensive.
+#
+# A zero-amplitude slot is treated as an absent feature: a duplicated model has no TIV
+# ending on it, so every term whose split involves that slot is gated to zero weight — not
+# only the terms whose own amplitude product vanishes. Without the gate, a head term would
+# be counted once per padded tail pairing, with a width computed from the padding σ.
+function tiv_pairwise_consts(
+        tivx::StackedTIVGMM{N, T, Lx, K}, tivy::StackedTIVGMM{N, S, Ly, K}, interactions::Dict{Tuple{K, K}, V}
+    ) where {N, T, S, Lx, Ly, K, V <: Number}
+    validate_interactions(interactions) || throw(ArgumentError("Interactions must not include redundant key pairs (i.e. (k1,k2) and (k2,k1))"))
+    t = promote_type(T, S, V)
+
+    uxs = unique!([l for ls in Iterators.flatten((tivx.headlabels, tivx.taillabels)) for l in ls])
+    uys = unique!([l for ls in Iterators.flatten((tivy.headlabels, tivy.taillabels)) for l in ls])
+    coefs = t[interaction_coefficient(interactions, kx, ky) for kx in uxs, ky in uys]
+    hix = [map(l -> findfirst(isequal(l), uxs)::Int, ls) for ls in tivx.headlabels]
+    tix = [map(l -> findfirst(isequal(l), uxs)::Int, ls) for ls in tivx.taillabels]
+    hiy = [map(l -> findfirst(isequal(l), uys)::Int, ls) for ls in tivy.headlabels]
+    tiy = [map(l -> findfirst(isequal(l), uys)::Int, ls) for ls in tivy.taillabels]
+
+    P = 2 * Lx * Lx * Ly * Ly
+    pσ = Matrix{SVector{P, t}}(undef, length(tivx), length(tivy))
+    pϕ = Matrix{SVector{P, t}}(undef, length(tivx), length(tivy))
+    sbuf = MVector{P, t}(undef)
+    wbuf = MVector{P, t}(undef)
+    for i in eachindex(tivx.gaussians)
+        xhσ, xtσ, xhϕ, xtϕ = tivx.headσ[i], tivx.tailσ[i], tivx.headϕ[i], tivx.tailϕ[i]
+        chx, ctx = hix[i], tix[i]
+        for j in eachindex(tivy.gaussians)
+            yhσ, ytσ, yhϕ, ytϕ = tivy.headσ[j], tivy.tailσ[j], tivy.headϕ[j], tivy.tailϕ[j]
+            chy, cty = hiy[j], tiy[j]
+            m = 0
+            for a in 1:Lx, c in 1:Ly
+                s_h = xhσ[a]^2 + yhσ[c]^2
+                w_h = coefs[chx[a], chy[c]] * xhϕ[a] * yhϕ[c]
+                head_present = !(iszero(xhϕ[a]) || iszero(yhϕ[c]))
+                for b in 1:Lx, d in 1:Ly
+                    s_t = xtσ[b]^2 + ytσ[d]^2
+                    s_sum = s_h + s_t
+                    tail_present = !(iszero(xtϕ[b]) || iszero(ytϕ[d]))
+                    sbuf[m + 1] = s_sum^2 / s_h
+                    sbuf[m + 2] = s_sum^2 / s_t
+                    wbuf[m + 1] = tail_present ? w_h : zero(t)
+                    wbuf[m + 2] = head_present ? coefs[ctx[b], cty[d]] * xtϕ[b] * ytϕ[d] : zero(t)
+                    m += 2
+                end
+            end
+            pσ[i, j] = SVector(sbuf)
+            pϕ[i, j] = SVector(wbuf)
+        end
+    end
+    return pσ, pϕ
+end
+
+# mixed TIV models lift the unstacked side to a single-slot StackedTIVGMM; Nothing and Dict
+# methods keep these more specific than the `(AbstractGMM, AbstractGMM, Nothing)` fallback
+tiv_pairwise_consts(tivx::StackedTIVGMM{N, T, L, K}, tivy::TIVGMM{N, S, K}, interactions::Nothing) where {N, T, L, K, S} =
+    tiv_pairwise_consts(tivx, StackedTIVGMM(tivy), interactions)
+tiv_pairwise_consts(tivx::StackedTIVGMM{N, T, L, K}, tivy::TIVGMM{N, S, K}, interactions::Dict{Tuple{K, K}, V}) where {N, T, L, K, S, V <: Number} =
+    tiv_pairwise_consts(tivx, StackedTIVGMM(tivy), interactions)
+tiv_pairwise_consts(tivx::TIVGMM{N, T, K}, tivy::StackedTIVGMM{N, S, L, K}, interactions::Nothing) where {N, T, K, S, L} =
+    tiv_pairwise_consts(StackedTIVGMM(tivx), tivy, interactions)
+tiv_pairwise_consts(tivx::TIVGMM{N, T, K}, tivy::StackedTIVGMM{N, S, L, K}, interactions::Dict{Tuple{K, K}, V}) where {N, T, K, S, L, V <: Number} =
+    tiv_pairwise_consts(StackedTIVGMM(tivx), tivy, interactions)

--- a/src/gogma/transformation.jl
+++ b/src/gogma/transformation.jl
@@ -46,6 +46,42 @@ end
 
 Base.:-(x::TIVGMM, T::AbstractVector) = x + (-T)
 
+function Base.:*(R::AbstractMatrix{W}, g::StackedLabeledGaussian{N, V, L, K}) where {N, V, L, K, W}
+    numtype = promote_type(V, W)
+    return StackedLabeledGaussian{N, numtype, L, K}(R * g.μ, g.σ, g.ϕ, g.labels)
+end
+
+function Base.:+(g::StackedLabeledGaussian{N, V, L, K}, T::AbstractVector{W}) where {N, V, L, K, W}
+    numtype = promote_type(V, W)
+    return StackedLabeledGaussian{N, numtype, L, K}(g.μ .+ T, g.σ, g.ϕ, g.labels)
+end
+
+Base.:-(g::StackedLabeledGaussian, T::AbstractVector) = g + (-T)
+
+function Base.:*(R::AbstractMatrix{W}, x::AbstractStackedLabeledIsotropicGMM{N, V, L, K}) where {N, V, L, K, W}
+    numtype = promote_type(V, W)
+    return StackedLabeledIsotropicGMM{N, numtype, L, K}([R * g for g in x.gaussians])
+end
+
+function Base.:+(x::AbstractStackedLabeledIsotropicGMM{N, V, L, K}, T::AbstractVector{W}) where {N, V, L, K, W}
+    numtype = promote_type(V, W)
+    return StackedLabeledIsotropicGMM{N, numtype, L, K}([g + T for g in x.gaussians])
+end
+
+Base.:-(x::AbstractStackedLabeledIsotropicGMM, T::AbstractVector) = x + (-T)
+
+function Base.:*(R::AbstractMatrix{W}, x::StackedTIVGMM{N, V, L, K}) where {N, V, L, K, W}
+    numtype = promote_type(V, W)
+    return StackedTIVGMM{N, numtype, L, K}([R * g for g in x.gaussians], x.headσ, x.headϕ, x.headlabels, x.tailσ, x.tailϕ, x.taillabels)
+end
+
+function Base.:+(x::StackedTIVGMM{N, V, L, K}, T::AbstractVector{W}) where {N, V, L, K, W}
+    numtype = promote_type(V, W)
+    return StackedTIVGMM{N, numtype, L, K}([g + T for g in x.gaussians], x.headσ, x.headϕ, x.headlabels, x.tailσ, x.tailϕ, x.taillabels)
+end
+
+Base.:-(x::StackedTIVGMM, T::AbstractVector) = x + (-T)
+
 function Base.:*(R::AbstractMatrix{W}, x::IsotropicMultiGMM{N, V, K}) where {N, V, K, W}
     numtype = promote_type(V, W)
     gmmdict = Dict{K, IsotropicGMM{N, numtype}}()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1410,3 +1410,310 @@ end
     # the interactions keyword is threaded through without breaking the unlabeled path
     @test isfinite(tiv_gogma_align(Rtrue * IsotropicGMM(x.gaussians), IsotropicGMM(x.gaussians); cutoff_x = 3.0, cutoff_y = 3.0, maxsplits = 2.0e3).upperbound)
 end
+
+@testset "StackedLabeledGaussian and StackedLabeledIsotropicGMM" begin
+    g = StackedLabeledGaussian([0.0, 0.0, 1.0], [0.5, 0.8], [1.0, 2.0], [:a, :b])
+    @test g isa StackedLabeledGaussian{3, Float64, 2, Symbol}
+    @test g isa GMA.AbstractIsotropicGaussian{3, Float64}
+    @test g.μ === SVector(0.0, 0.0, 1.0)
+    @test g.σ === SVector(0.5, 0.8) && g.ϕ === SVector(1.0, 2.0) && g.labels === SVector(:a, :b)
+
+    # point evaluation is the sum of the slot Gaussians
+    pos = [0.3, -0.2, 0.4]
+    @test g(pos) ≈ sum(ϕ * exp(-sum(abs2, pos - g.μ) / (2σ^2)) for (σ, ϕ) in zip(g.σ, g.ϕ))
+
+    # numeric promotion in the outer constructor
+    @test StackedLabeledGaussian([0, 0, 1], [1, 1], [1.0f0, 2.0f0], [:a, :b]) isa StackedLabeledGaussian{3, Float32, 2, Symbol}
+
+    # fail-fast validation
+    @test_throws DimensionMismatch StackedLabeledGaussian([0.0, 0.0, 1.0], [0.5], [1.0, 2.0], [:a, :b])
+    @test_throws "all slot widths must be positive" StackedLabeledGaussian([0.0, 0.0, 1.0], [0.5, 0.0], [1.0, 0.0], [:a, :a])
+    @test_throws "all slot widths must be positive" StackedLabeledGaussian([0.0, 0.0, 1.0], [0.5, -1.0], [1.0, 2.0], [:a, :b])
+
+    # single-slot lift from a plain Gaussian
+    lifted = StackedLabeledGaussian(IsotropicGaussian([1.0, 0.0, 0.0], 0.7, 1.5), :c)
+    @test lifted isa StackedLabeledGaussian{3, Float64, 1, Symbol}
+    @test lifted.σ == SVector(0.7) && lifted.labels == SVector(:c)
+
+    # copy, convert, promote
+    @test StackedLabeledGaussian(g) == g
+    @test convert(StackedLabeledGaussian{3, Float32, 2, Symbol}, g) isa StackedLabeledGaussian{3, Float32, 2, Symbol}
+    @test promote_type(typeof(g), StackedLabeledGaussian{3, Float32, 2, Symbol}) === typeof(g)
+
+    g2 = StackedLabeledGaussian([1.0, 1.0, 0.0], [0.6, 1.0], [1.5, 0.0], [:a, :a])
+    gmm = StackedLabeledIsotropicGMM([g, g2])
+    @test gmm isa StackedLabeledIsotropicGMM{3, Float64, 2, Symbol}
+    @test gmm isa GMA.AbstractStackedLabeledIsotropicGMM{3, Float64, 2, Symbol}
+    @test gmm isa GMA.AbstractIsotropicGMM{3, Float64}
+    @test !(gmm isa GMA.AbstractLabeledIsotropicGMM)
+    @test length(gmm) == 2
+    @test gmm[2] == g2
+    @test collect(gmm) == [g, g2]
+    @test eltype(gmm) === eltype(typeof(gmm)) === StackedLabeledGaussian{3, Float64, 2, Symbol}
+    @test isempty(StackedLabeledIsotropicGMM{3, Float64, 2, Symbol}())
+    @test StackedLabeledIsotropicGMM(gmm).gaussians == gmm.gaussians
+    @test convert(StackedLabeledIsotropicGMM{3, Float32, 2, Symbol}, gmm) isa StackedLabeledIsotropicGMM{3, Float32, 2, Symbol}
+    @test gmm(pos) ≈ g(pos) + g2(pos)
+
+    # show smoke tests
+    @test occursin("labels", sprint(show, g))
+    @test occursin("StackedLabeledGaussian", sprint(show, gmm))
+
+    # accessors: weights sum slot amplitudes; widths are amplitude-weighted RMS widths
+    @test GMA.coords(gmm) == [g.μ g2.μ]
+    @test GMA.weights(gmm) == [3.0, 1.5]
+    @test GMA.widths(gmm) ≈ [sqrt((1.0 * 0.5^2 + 2.0 * 0.8^2) / 3.0), 0.6]
+    allpad = StackedLabeledIsotropicGMM([StackedLabeledGaussian([0.0, 0.0, 0.0], [1.0, 1.0], [0.0, 0.0], [:a, :a])])
+    @test GMA.weights(allpad) == [0.0]
+    @test GMA.widths(allpad) == [0.0]
+
+    # per-point construction with automatic padding
+    padded = StackedLabeledIsotropicGMM(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
+        [[0.5, 0.8], [0.9]], [[1.0, 2.0], [1.5]], [[:a, :b], [:c]]
+    )
+    @test padded isa StackedLabeledIsotropicGMM{3, Float64, 2, Symbol}
+    @test padded.gaussians[2].σ == SVector(0.9, 1.0)
+    @test padded.gaussians[2].ϕ == SVector(1.5, 0.0)
+    @test padded.gaussians[2].labels == SVector(:c, :c)
+    @test_throws DimensionMismatch StackedLabeledIsotropicGMM([[0.0, 0.0, 0.0]], [[0.5]], [[1.0, 2.0]], [[:a]])
+    @test_throws "has no features" StackedLabeledIsotropicGMM([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], [[0.5], Float64[]], [[1.0], Float64[]], [[:a], Symbol[]])
+
+    # single-slot lift from a labeled GMM (no grouping)
+    labgmm = LabeledIsotropicGMM([IsotropicGaussian([0.0, 0.0, 0.0], 0.5, 1.0), IsotropicGaussian([0.0, 0.0, 0.0], 0.8, 2.0)], [:a, :b])
+    lifted_gmm = StackedLabeledIsotropicGMM(labgmm)
+    @test lifted_gmm isa StackedLabeledIsotropicGMM{3, Float64, 1, Symbol}
+    @test length(lifted_gmm) == 2
+
+    # stackedgmm groups exactly equal means and pads shorter groups
+    grouped = stackedgmm(labgmm)
+    @test grouped isa StackedLabeledIsotropicGMM{3, Float64, 2, Symbol}
+    @test length(grouped) == 1
+    @test grouped.gaussians[1].σ == SVector(0.5, 0.8)
+    @test grouped.gaussians[1].labels == SVector(:a, :b)
+end
+
+@testset "stacked transformations" begin
+    g = StackedLabeledGaussian([0.0, 0.0, 1.0], [0.5, 0.8], [1.0, 2.0], [:a, :b])
+    gmm = StackedLabeledIsotropicGMM([g, StackedLabeledGaussian([1.0, 1.0, 0.0], [0.6, 1.0], [1.5, 0.0], [:a, :a])])
+    R = RotationVec(0.4, -0.3, 0.7)
+    T = SVector(1.0, -2.0, 0.5)
+    affine = AffineMap(R, T)
+
+    tg = affine(g)
+    @test tg isa typeof(g)
+    @test tg.μ ≈ R * g.μ + T
+    @test tg.σ == g.σ && tg.ϕ == g.ϕ && tg.labels == g.labels
+    @test (@inferred affine(g)) isa typeof(g)
+    @test ((g + T) - T).μ ≈ g.μ
+
+    tgmm = affine(gmm)
+    @test tgmm isa typeof(gmm)
+    @test (@inferred affine(gmm)) isa typeof(gmm)
+    @test all(tG.σ == G.σ && tG.ϕ == G.ϕ && tG.labels == G.labels for (tG, G) in zip(tgmm.gaussians, gmm.gaussians))
+    @test GMA.coords(tgmm) ≈ R * GMA.coords(gmm) .+ T
+
+    # overlap is invariant under a shared rigid transformation
+    other = StackedLabeledIsotropicGMM([StackedLabeledGaussian([0.5, 0.2, -0.3], [0.7, 0.9], [1.0, 0.5], [:a, :b])])
+    @test overlap(affine(gmm), affine(other)) ≈ overlap(gmm, other)
+end
+
+@testset "stacked equals duplicated labeled model" begin
+    # a labeled model with duplicate-mean groups of sizes 3, 2, and 1, including a negative
+    # amplitude and label pairs with negative or absent interaction coefficients
+    pts = [SVector(0.0, 0.0, 0.0), SVector(3.0, 0.0, 0.0), SVector(0.0, 4.0, 0.0)]
+    feats = [
+        [(0.5, 1.0, :a), (0.8, 2.0, :b), (1.1, -0.5, :c)],
+        [(0.6, 1.5, :a), (0.9, 0.7, :c)],
+        [(1.0, 1.2, :b)],
+    ]
+    gaussians = IsotropicGaussian{3, Float64}[]
+    labels = Symbol[]
+    for (p, fs) in zip(pts, feats), (σ, ϕ, lab) in fs
+        push!(gaussians, IsotropicGaussian(p, σ, ϕ))
+        push!(labels, lab)
+    end
+    lab_x = LabeledIsotropicGMM(gaussians, labels)
+    stk_x = stackedgmm(lab_x)
+    @test stk_x isa StackedLabeledIsotropicGMM{3, Float64, 3, Symbol}
+    @test length(stk_x) == 3 && length(lab_x) == 6
+
+    tform = AffineMap(RotationVec(0.3, -0.2, 0.5), SVector(1.0, -1.0, 2.0))
+    lab_y, stk_y = tform(lab_x), stackedgmm(tform(lab_x))
+    interactions = Dict((:a, :a) => 1.0, (:b, :b) => 0.5, (:a, :c) => -0.3)
+
+    # overlaps match, with and without interactions
+    @test overlap(stk_x, stk_y; interactions) ≈ overlap(lab_x, lab_y; interactions) rtol = 1e-12
+    @test overlap(stk_x, stk_y) ≈ overlap(lab_x, lab_y) rtol = 1e-12
+
+    # pairwise constants: one SVector{Lx*Ly} entry per mean pair, zero weight for padded
+    # and non-interacting slot pairs
+    pσ, pϕ = GMA.pairwise_consts(stk_x, stk_y, interactions)
+    @test pσ isa Matrix{SVector{9, Float64}} && pϕ isa Matrix{SVector{9, Float64}}
+    @test size(pσ) == (3, 3)
+    # point 3 has one feature (:b): against point 3 only the (1, 1) slot pair can interact
+    @test count(!iszero, pϕ[3, 3]) == 1
+    @test pϕ[3, 3][1] ≈ 0.5 * 1.2 * 1.2
+    @test pσ[3, 3][1] ≈ 1.0^2 + 1.0^2
+    # slot-pair weights carry the interaction coefficients: (:a, :c) → -0.3
+    g1, g1y = stk_x.gaussians[1], stk_y.gaussians[2]
+    m_ac = findfirst(m -> (fldmod1(m, 3) == (1, 2)), 1:9)  # slot 1 (:a) of x vs slot 2 (:c) of y
+    @test pϕ[1, 2][m_ac] ≈ -0.3 * g1.ϕ[1] * g1y.ϕ[2]
+
+    # the mean-pair distance bounds are shared, so bounds match the duplicated model exactly
+    plσ, plϕ = GMA.pairwise_consts(lab_x, lab_y, interactions)
+    R, T = RotationVec(0.1, 0.2, -0.1), SVector(0.5, -0.3, 0.2)
+    for (σᵣ, σₜ) in ((0.5, 0.5), (0.1, 1.0), (1.0, 0.05))
+        b_lab = gauss_l2_bounds(lab_x, lab_y, R, T, σᵣ, σₜ, plσ, plϕ)
+        b_stk = gauss_l2_bounds(stk_x, stk_y, R, T, σᵣ, σₜ, pσ, pϕ)
+        @test all(isapprox.(b_lab, b_stk; atol = 1e-12))
+        @test b_stk[1] <= -overlap(AffineMap(R, T)(stk_x), stk_y, pσ, pϕ) <= b_stk[2] + 1e-12
+    end
+
+    # pσ/pϕ index the Gaussians from 1
+    @test_throws ArgumentError overlap(stk_x, stk_y, OffsetArray(pσ, -1, -1), OffsetArray(pϕ, -1, -1))
+
+    # Gaussian-pair overlap sums the slot cross-terms at the shared distance
+    gx, gy = stk_x.gaussians[1], stk_y.gaussians[2]
+    distsq = sum(abs2, gx.μ - gy.μ)
+    manual = sum(
+        GMA.interaction_coefficient(interactions, gx.labels[k], gy.labels[l]) * gx.ϕ[k] * gy.ϕ[l] *
+            exp(-distsq / (2 * (gx.σ[k]^2 + gy.σ[l]^2)))
+            for k in 1:3, l in 1:3
+    )
+    @test overlap(gx, gy; interactions) ≈ manual rtol = 1e-12
+    @test overlap(gx, gy) ≈ sum(
+        (gx.labels[k] == gy.labels[l]) * gx.ϕ[k] * gy.ϕ[l] * exp(-distsq / (2 * (gx.σ[k]^2 + gy.σ[l]^2)))
+            for k in 1:3, l in 1:3
+    ) rtol = 1e-12
+
+    # forces match the duplicated model
+    f_stk, f_lab = zeros(3), zeros(3)
+    GMA.force!(f_stk, stk_x, stk_y; interactions)
+    GMA.force!(f_lab, lab_x, lab_y; interactions)
+    @test f_stk ≈ f_lab rtol = 1e-10
+
+    # mixed stacked × labeled overlaps lift the labeled side
+    @test overlap(stk_x, lab_y; interactions) ≈ overlap(lab_x, lab_y; interactions) rtol = 1e-12
+    @test overlap(lab_x, stk_y; interactions) ≈ overlap(lab_x, lab_y; interactions) rtol = 1e-12
+
+    # unlabeled models cannot be paired with stacked ones
+    iso = IsotropicGMM([IsotropicGaussian(SVector(0.0, 0.0, 0.0), 1.0, 1.0)])
+    @test_throws "wrap the IsotropicGMM in a LabeledIsotropicGMM" GMA.pairwise_consts(stk_x, iso)
+    @test_throws "wrap the IsotropicGMM in a LabeledIsotropicGMM" GMA.pairwise_consts(iso, stk_x)
+end
+
+@testset "stacked TIV" begin
+    # nonnegative amplitudes: TIV selection scores take geometric means of amplitudes
+    pts = [SVector(0.0, 0.0, 0.0), SVector(3.0, 0.0, 0.0), SVector(0.0, 4.0, 0.0)]
+    feats = [
+        [(0.5, 1.0, :a), (0.8, 2.0, :b), (1.1, 0.5, :c)],
+        [(0.6, 1.5, :a), (0.9, 0.7, :c)],
+        [(1.0, 1.2, :b)],
+    ]
+    gaussians = IsotropicGaussian{3, Float64}[]
+    labels = Symbol[]
+    for (p, fs) in zip(pts, feats), (σ, ϕ, lab) in fs
+        push!(gaussians, IsotropicGaussian(p, σ, ϕ))
+        push!(labels, lab)
+    end
+    lab_x = LabeledIsotropicGMM(gaussians, labels)
+    stk_x = stackedgmm(lab_x)
+    tform = AffineMap(RotationVec(0.3, -0.2, 0.5), SVector(1.0, -1.0, 2.0))
+    lab_y, stk_y = tform(lab_x), stackedgmm(tform(lab_x))
+    interactions = Dict((:a, :a) => 1.0, (:b, :b) => 0.5, (:a, :c) => -0.3)
+
+    # structure: one TIV per ordered pair of distinct stacked points, with slot-wise endpoint data
+    tivs_x = GMA.tivgmm(stk_x, Inf)
+    @test tivs_x isa GMA.StackedTIVGMM{3, Float64, 3, Symbol}
+    @test length(tivs_x) == length(stk_x)^2 - length(stk_x)
+    @test length(tivs_x.headσ) == length(tivs_x) && length(tivs_x.taillabels) == length(tivs_x)
+
+    # a mean-duplicated model produces the same TIV overlap once its zero-length TIVs
+    # (between co-located duplicate features) are removed: those pair overlaps are
+    # rotation-independent constants that a stacked model deliberately omits
+    tivd_full = GMA.tivgmm(lab_x, Inf)
+    keep = [i for i in eachindex(tivd_full.gaussians) if !iszero(norm(tivd_full.gaussians[i].μ))]
+    tivd_x = GMA.TIVGMM(
+        tivd_full.gaussians[keep], tivd_full.headσ[keep], tivd_full.headϕ[keep], tivd_full.headlabels[keep],
+        tivd_full.tailσ[keep], tivd_full.tailϕ[keep], tivd_full.taillabels[keep]
+    )
+    tivd_yfull = GMA.tivgmm(lab_y, Inf)
+    keepy = [i for i in eachindex(tivd_yfull.gaussians) if !iszero(norm(tivd_yfull.gaussians[i].μ))]
+    tivd_y = GMA.TIVGMM(
+        tivd_yfull.gaussians[keepy], tivd_yfull.headσ[keepy], tivd_yfull.headϕ[keepy], tivd_yfull.headlabels[keepy],
+        tivd_yfull.tailσ[keepy], tivd_yfull.tailϕ[keepy], tivd_yfull.taillabels[keepy]
+    )
+    tivs_y = GMA.tivgmm(stk_y, Inf)
+
+    dpσ, dpϕ = GMA.tiv_pairwise_consts(tivd_x, tivd_y, interactions)
+    spσ, spϕ = GMA.tiv_pairwise_consts(tivs_x, tivs_y, interactions)
+    @test spσ isa Matrix{SVector{162, Float64}}  # 2 ⋅ 3² ⋅ 3² terms per TIV pair
+    for R in (RotationVec(0.0, 0.0, 0.0), RotationVec(0.3, -0.2, 0.5), RotationVec(-1.0, 0.4, 0.9))
+        @test overlap(R * tivs_x, tivs_y, spσ, spϕ) ≈ overlap(R * tivd_x, tivd_y, dpσ, dpϕ) rtol = 1e-10
+    end
+    dpσ0, dpϕ0 = GMA.tiv_pairwise_consts(tivd_x, tivd_y, nothing)
+    spσ0, spϕ0 = GMA.tiv_pairwise_consts(tivs_x, tivs_y, nothing)
+    R = RotationVec(0.3, -0.2, 0.5)
+    @test overlap(R * tivs_x, tivs_y, spσ0, spϕ0) ≈ overlap(R * tivd_x, tivd_y, dpσ0, dpϕ0) rtol = 1e-10
+
+    # full TIV alignment recovers the self-overlap, matching the labeled model
+    res_stk = tiv_gogma_align(stk_x, stk_y; interactions, maxsplits = 2e3)
+    res_lab = tiv_gogma_align(lab_x, lab_y; interactions, maxsplits = 2e3)
+    @test res_stk.upperbound ≈ res_lab.upperbound rtol = 1e-6
+    @test res_stk.upperbound ≈ -overlap(stk_x, stk_x; interactions) rtol = 1e-4
+
+    # mixed stacked × labeled TIV alignment lifts the labeled side
+    res_mixed = tiv_gogma_align(stk_x, lab_y; interactions, maxsplits = 1e3)
+    @test isfinite(res_mixed.upperbound)
+end
+
+@testset "stacked GOGMA and local alignment" begin
+    pts = [SVector(0.0, 0.0, 0.0), SVector(3.0, 0.0, 0.0), SVector(0.0, 4.0, 0.0)]
+    feats = [
+        [(0.5, 1.0, :a), (0.8, 2.0, :b), (1.1, 0.5, :c)],
+        [(0.6, 1.5, :a), (0.9, 0.7, :c)],
+        [(1.0, 1.2, :b)],
+    ]
+    μs = eltype(pts)[]
+    σs, ϕs, labelss = Vector{Float64}[], Vector{Float64}[], Vector{Symbol}[]
+    for (p, fs) in zip(pts, feats)
+        push!(μs, p)
+        push!(σs, [f[1] for f in fs])
+        push!(ϕs, [f[2] for f in fs])
+        push!(labelss, [f[3] for f in fs])
+    end
+    stk_x = StackedLabeledIsotropicGMM(μs, σs, ϕs, labelss)
+    tform = AffineMap(RotationVec(0.3, -0.2, 0.5), SVector(1.0, -1.0, 2.0))
+    stk_y = tform(stk_x)
+    interactions = Dict((:a, :a) => 1.0, (:b, :b) => 0.5, (:a, :c) => -0.3)
+
+    res = gogma_align(stk_x, stk_y; interactions, maxsplits = 2e3)
+    @test res.upperbound ≈ -overlap(stk_x, stk_x; interactions) rtol = 1e-4
+
+    resr = GMA.rot_gogma_align(stk_x, stk_x; interactions, maxsplits = 500)
+    rest = GMA.trl_gogma_align(stk_x, stk_x; interactions, maxsplits = 500)
+    @test resr.upperbound ≈ -overlap(stk_x, stk_x; interactions) rtol = 1e-4
+    @test rest.upperbound ≈ -overlap(stk_x, stk_x; interactions) rtol = 1e-4
+
+    # rocs_align consumes the stacked weights/widths accessors
+    rres = rocs_align(stk_x, stk_y)
+    @test rres.minimum ≈ -overlap(stk_x, stk_x) atol = 1e-9
+
+    # autodiff: gradients through padded slots are finite and match the duplicated model
+    lab_equiv = LabeledIsotropicGMM(
+        [IsotropicGaussian(p, σ, ϕ) for (p, fs) in zip(pts, feats) for (σ, ϕ, _) in fs],
+        [lab for fs in feats for (_, _, lab) in fs]
+    )
+    lab_yequiv = tform(lab_equiv)
+    pσ, pϕ = GMA.pairwise_consts(stk_x, stk_y, interactions)
+    plσ, plϕ = GMA.pairwise_consts(lab_equiv, lab_yequiv, interactions)
+    X = [0.1, -0.2, 0.3, 0.5, -0.1, 0.2]
+    grad_stk = ForwardDiff.gradient(X -> overlapobj(X, stk_x, stk_y, pσ, pϕ), X)
+    grad_lab = ForwardDiff.gradient(X -> overlapobj(X, lab_equiv, lab_yequiv, plσ, plϕ), X)
+    @test all(isfinite, grad_stk)
+    @test grad_stk ≈ grad_lab rtol = 1e-8
+
+    res_ad = gogma_align(stk_x, stk_y; interactions, autodiff = AutoForwardDiff(), maxsplits = 100)
+    @test isfinite(res_ad.upperbound)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -215,6 +215,8 @@ end
     @test !isa(GMA.coords(gmm), StaticArray)
     @test !isa(GMA.weights(gmm), StaticArray)
     @test !isa(GMA.widths(gmm), StaticArray)
+    @test GMA.weights(gmm) == [g.ϕ for g in s_gs] == fill(1.0, 4)
+    @test GMA.widths(gmm) == [g.σ for g in s_gs] == fill(0.5, 4)
     mgmmx = IsotropicMultiGMM(
         Dict(
             :positive => IsotropicGMM([ch_g]),
@@ -244,6 +246,7 @@ end
     @test !isa(GMA.coords(mgmmx), StaticArray)
     @test !isa(GMA.weights(mgmmx), StaticArray)
     @test !isa(GMA.widths(mgmmx), StaticArray)
+    @test sort(GMA.widths(mgmmx)) == [0.5, 0.5, 0.5, 0.5, 1.0]
     empty!(mgmmx)
     @test isempty(mgmmx)
 end
@@ -403,6 +406,12 @@ end
 
     # ROCS alignment should work perfectly for these GMMs
     @test isapprox(rocs_align(gmmx, gmmy).minimum, -overlap(gmmx, gmmx); atol = 1.0e-12)
+
+    # non-uniform σ and ϕ: the inertial starting orientations depend on the widths through
+    # the mass matrix, so recovery here requires `widths` to actually return σ
+    gx2 = IsotropicGMM([IsotropicGaussian(x, 0.5 + 0.3i, 1.0 + 0.5i) for (i, x) in enumerate(xpts)])
+    gy2 = AffineMap(RotationVec(0.4, -0.3, 0.7), SVector(1.0, -2.0, 0.5))(gx2)
+    @test isapprox(rocs_align(gx2, gy2).minimum, -overlap(gx2, gx2); atol = 1.0e-6)
 end
 
 @testset "AlignmentResults interface" begin


### PR DESCRIPTION
This adds "stacked" GMM types for models that have concentric features

### Problem
Models with several concentric features must currently duplicate a mean once per feature. Since branch-and-bound cost is dominated by per-pair distance-bound evaluations, stacking 3 features per point in both models means 9 distance computations per point pair where 1 suffices — the cost scales quadratically in the stacking degree.

### What this adds
- **`StackedLabeledGaussian{N,T,L,K}`** — `L` labeled isotropic features stacked on a single mean `μ`, with slot-wise widths, amplitudes, and labels stored as `SVector{L}`s.
- **`StackedLabeledIsotropicGMM{N,T,L,K}`** collects them with a uniform stacking degree, enforced by the concrete element type for type stability. Variable stacking is handled by padding: unused slots carry `ϕ = 0` (and any positive σ, validated fail-fast) and contribute nothing anywhere.
- `pairwise_consts` for a stacked pair produces one `SVector{Lx·Ly}` of combined variances and weights per pair of means — the `SVector{2}` head/tail pattern of `tiv_pairwise_consts` generalized. These feed the existing multi-term `overlap` and `gauss_l2_bounds` kernels unchanged, so each distance and distance bound is computed once per mean pair and shared by
all slot cross-terms. `gogma_align`, `rot_`/`trl_gogma_align`, `local_align`, `rocs_align`, and `force!` all work through these methods with no changes to the branch-and-bound machinery.
- **TIV support** comes via `StackedTIVGMM`, which keeps slot-wise endpoint data and applies the head/tail variance split per pairing of endpoint slots (`2·Lx²·Ly²` terms per TIV pair). Terms whose split involves a zero-amplitude slot are gated to zero weight — a zero-amplitude slot is an absent feature, and the duplicated model has no TIV ending on one.
- Construction & interop: `stackedgmm(::LabeledIsotropicGMM)` groups exactly-equal means with automatic padding; a per-point `(μs, σs, ϕs, labelss)` constructor does the same for ragged input. Mixed stacked × labeled alignments lift the labeled side to a single-slot stacked model (exact, once per align call); pairing with an unlabeled `IsotropicGMM` throws an informative error. Exports: `StackedLabeledGaussian`, `StackedLabeledIsotropicGMM`, `stackedgmm`.  
- 
### Design notes
- `StackedLabeledIsotropicGMM` subtypes `AbstractIsotropicGMM`, deliberately not `AbstractLabeledIsotropicGMM`: every method on the labeled abstract assumes parallel `.labels::Vector` and scalar Gaussian σ/ϕ, so subtyping it would turn each into a
wrong-dispatch trap. A mirror abstract `AbstractStackedLabeledIsotropicGMM` preserves the extension pattern for downstream packages.
- Labels live inside the Gaussian rather than as a GMM-level parallel vector, so the inherited `push!`/`pop!` interface cannot desynchronize them.
- The σ-positivity check on padded slots closes a `0/0` NaN path for users differentiating with respect to amplitudes, where zero-valued dual weights are deliberately not skipped.

### Correctness
Stacked models reproduce their mean-duplicated `LabeledIsotropicGMM` equivalents to ~1e-10: overlaps, `gauss_l2_bounds` at multiple search regions, forces, ForwardDiff gradients, and TIV rotation objectives (exact up to the rotation-independent zero-length TIVs that duplicated means create), including negative amplitudes, negative/absent interaction coefficients, and ragged stacking. 97 new test assertions across five testsets.

### Performance
For n = 30 points at stacking degree 3, `gauss_l2_bounds` runs ×2.2–3.9 faster depending on how many slot-label pairs interact (the duplicated representation already skips zero-weight pairs before their distance bound), and `gogma_align` end-to-end runs ×2.7 faster with a typical sparse interaction dict. The per-TIV-pair term count grows as L⁴, so large stacking degrees are expensive in the TIV path.

### Limitations
- `tivgmm` selection scoring (`√(ϕx·ϕy)`, pre-existing) rejects negative amplitudes in all TIV paths.
- `convert(IsotropicGaussian, ::StackedLabeledGaussian)` and `combine` across stacked/plain types are unsupported.
- Approximate (tolerance-based) mean grouping in `stackedgmm` is left as future work; grouping is by exact `μ` equality.

