### PR TITLE
Store only nonzero-weight terms in stacked constants

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GaussianMixtureAlignment"
 uuid = "f2431ed1-b9c2-4fdb-af1b-a74d6c93b3b3"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Tom McGrath <tmcgrath325@gmail.com> and contributors"]
 
 [deps]

--- a/src/gogma/bounds.jl
+++ b/src/gogma/bounds.jl
@@ -21,11 +21,13 @@ inputs the results are dense matrices indexed by Gaussian; for `AbstractMultiGMM
 are nested dictionaries keyed by component label, with `interactions` weighting the
 cross-label terms.
 
-For `AbstractStackedLabeledIsotropicGMM` inputs the matrices hold one `SVector{Lx*Ly}` per
-pair of stacked points — one combined variance and one weight per pairing of feature slots —
+For `AbstractStackedLabeledIsotropicGMM` inputs the matrices hold one `SVector` per pair of
+stacked points — one combined variance and one weight per pairing of feature slots —
 consumed termwise by the multi-term `overlap` and `gauss_l2_bounds` kernels at the single
 distance between the shared means (the same layout `tiv_pairwise_consts` uses for the head
-and tail terms of a TIV pair).
+and tail terms of a TIV pair). Only pairings with a nonzero weight are stored, so the
+`SVector` length is the largest such count over all pairs rather than `Lx*Ly`; it therefore
+depends on run-time values, and the `*_align` entry points act as function barriers.
 
 These constants depend only on the Gaussians' widths and amplitudes, not on the relative
 transformation, so they are invariant under the rigid search. They are the per-pair inputs to
@@ -104,11 +106,13 @@ function pairwise_consts(gmmx::AbstractLabeledIsotropicGMM{N, T, K}, gmmy::Abstr
     return pσ, pϕ
 end
 
-# For stacked GMMs, a pair's overlap is the sum of one term per pairing of feature slots,
-# all sharing the mean pair's single distance: entry `m` of `pσ[i,j]`/`pϕ[i,j]` holds the
-# combined variance and weight of slot pair `(k, l) = fldmod1(m, Ly)`. Zero-amplitude
-# (padded) and non-interacting slot pairs get zero weight and are skipped by the multi-term
-# `overlap` and `gauss_l2_bounds` kernels.
+# For stacked GMMs, a pair's overlap is the sum of one term per pairing of feature slots, all
+# sharing the mean pair's single distance. Only the pairings with a nonzero weight are stored:
+# a padded slot or a non-interacting label pair contributes nothing to any consumer, all of
+# which skip zero weights, so storing such a pairing would only lengthen the scan. Term
+# position carries no meaning — every consumer reads `pσ[i,j][m]` and `pϕ[i,j][m]` together
+# and sums over `m` — but the two must be filled from the same pairings, or a weight is
+# silently paired with the wrong variance.
 function pairwise_consts(
         gmmx::AbstractStackedLabeledIsotropicGMM{N, T, Lx, K}, gmmy::AbstractStackedLabeledIsotropicGMM{N, S, Ly, K},
         interactions::Nothing = nothing
@@ -140,25 +144,45 @@ function pairwise_consts(
     ix = [map(l -> findfirst(isequal(l), uxs)::Int, g.labels) for g in gxs]
     iy = [map(l -> findfirst(isequal(l), uys)::Int, g.labels) for g in gys]
 
-    P = Lx * Ly
-    pσ = Matrix{SVector{P, t}}(undef, length(gmmx), length(gmmy))
-    pϕ = Matrix{SVector{P, t}}(undef, length(gmmx), length(gmmy))
+    Q = 0
     for i in eachindex(gxs)
         gx, cx = gxs[i], ix[i]
         for j in eachindex(gys)
             gy, cy = gys[j], iy[j]
-            pσ[i, j] = SVector{P, t}(
-                ntuple(Val(P)) do m
-                    k, l = fldmod1(m, Ly)
-                    gx.σ[k]^2 + gy.σ[l]^2
-                end
-            )
-            pϕ[i, j] = SVector{P, t}(
-                ntuple(Val(P)) do m
-                    k, l = fldmod1(m, Ly)
-                    coefs[cx[k], cy[l]] * gx.ϕ[k] * gy.ϕ[l]
-                end
-            )
+            n = 0
+            for k in eachindex(gx.ϕ), l in eachindex(gy.ϕ)
+                iszero(coefs[cx[k], cy[l]] * gx.ϕ[k] * gy.ϕ[l]) || (n += 1)
+            end
+            Q = max(Q, n)
+        end
+    end
+    return stacked_consts(Val(Q), gxs, gys, ix, iy, coefs, t)
+end
+
+function stacked_consts(::Val{Q}, gxs, gys, ix, iy, coefs, ::Type{t}) where {Q, t}
+    pσ = Matrix{SVector{Q, t}}(undef, length(gxs), length(gys))
+    pϕ = Matrix{SVector{Q, t}}(undef, length(gxs), length(gys))
+    sbuf, wbuf = MVector{Q, t}(undef), MVector{Q, t}(undef)
+    for i in eachindex(gxs)
+        gx, cx = gxs[i], ix[i]
+        for j in eachindex(gys)
+            gy, cy = gys[j], iy[j]
+            m = 0
+            for k in eachindex(gx.ϕ), l in eachindex(gy.ϕ)
+                w = coefs[cx[k], cy[l]] * gx.ϕ[k] * gy.ϕ[l]
+                iszero(w) && continue
+                m += 1
+                sbuf[m] = gx.σ[k]^2 + gy.σ[l]^2
+                wbuf[m] = w
+            end
+            # unused slots must carry a positive variance: they are never read, but a zero
+            # would divide by zero if one ever were
+            for n in (m + 1):Q
+                sbuf[n] = one(t)
+                wbuf[n] = zero(t)
+            end
+            pσ[i, j] = SVector(sbuf)
+            pϕ[i, j] = SVector(wbuf)
         end
     end
     return pσ, pϕ

--- a/src/gogma/gmm.jl
+++ b/src/gogma/gmm.jl
@@ -80,6 +80,24 @@ coords(gmm::AbstractSingleGMM) = reduce(hcat, [g.μ for g in gmm.gaussians])
 weights(gmm::AbstractSingleGMM) = [g.ϕ for g in gmm.gaussians]
 widths(gmm::AbstractSingleGMM) = [g.σ for g in gmm.gaussians]
 
+"""
+    nfeatures(g::AbstractIsotropicGaussian)
+    nfeatures(gmm::AbstractGMM)
+
+Number of features a model carries, which for stacked models is not its `length`: a
+[`StackedLabeledGaussian`](@ref) occupies `L` slots but only the amplitude-nonzero ones are
+features, the rest being padding. Counting features rather than components makes a quantity
+comparable across a stacked model and the mean-duplicated `LabeledIsotropicGMM` it
+represents, where `length` is not.
+
+`iszero` is false for a dual number carrying a nonzero partial, so a slot that is
+zero-valued but differentiated counts as a feature.
+"""
+nfeatures(::AbstractIsotropicGaussian) = 1
+nfeatures(gmm::AbstractSingleGMM) = sum(nfeatures, gmm.gaussians; init = 0)
+nfeatures(mgmm::AbstractMultiGMM) = sum(nfeatures, values(mgmm.gmms); init = 0)
+# the StackedLabeledGaussian method is defined with that type, below
+
 length(mgmm::AbstractMultiGMM) = length(mgmm.gmms)
 getindex(mgmm::AbstractMultiGMM, k) = mgmm.gmms[k]
 keys(mgmm::AbstractMultiGMM) = keys(mgmm.gmms)
@@ -167,6 +185,33 @@ end
 
 LabeledIsotropicGMM(gaussians::AbstractVector{IsotropicGaussian{N, T}}, labels::AbstractVector{K}) where {N, T, K} = LabeledIsotropicGMM{N, T, K}(gaussians, labels)
 LabeledIsotropicGMM(gmm::AbstractLabeledIsotropicGMM) = LabeledIsotropicGMM(gmm.gaussians, gmm.labels)
+
+"""
+    LabeledIsotropicGMM(gmm::AbstractStackedLabeledIsotropicGMM)
+
+Unstack a stacked labeled GMM into the mean-duplicated model it represents: each component
+contributes one `IsotropicGaussian` per slot, repeating the component's mean and carrying
+that slot's width, amplitude, and label. Components keep their order, and slots keep theirs
+within a component, so this inverts [`stackedgmm`](@ref) and
+`StackedLabeledIsotropicGMM(::AbstractLabeledIsotropicGMM)` up to the grouping they apply.
+
+Amplitude-zero slots are padding rather than features (see [`StackedLabeledGaussian`](@ref))
+and are dropped. Overlaps, bounds, and forces are unchanged by the round trip, since a
+zero-amplitude slot contributes nothing. As elsewhere, `iszero` is false for a dual number
+carrying a nonzero partial, so a slot that is zero-valued but differentiated is kept.
+"""
+function LabeledIsotropicGMM(gmm::AbstractStackedLabeledIsotropicGMM{N, T, L, K}) where {N, T, L, K}
+    gaussians = IsotropicGaussian{N, T}[]
+    labels = K[]
+    for g in gmm.gaussians
+        for k in eachindex(g.σ, g.ϕ, g.labels)
+            iszero(g.ϕ[k]) && continue
+            push!(gaussians, IsotropicGaussian{N, T}(g.μ, g.σ[k], g.ϕ[k]))
+            push!(labels, g.labels[k])
+        end
+    end
+    return LabeledIsotropicGMM{N, T, K}(gaussians, labels)
+end
 LabeledIsotropicGMM{N, T, K}() where {N, T, K} = LabeledIsotropicGMM{N, T, K}(IsotropicGaussian{N, T}[], K[])
 
 convert(::Type{GMM}, gmm::AbstractLabeledIsotropicGMM) where {GMM <: LabeledIsotropicGMM} = GMM(gmm.gaussians, gmm.labels)
@@ -333,6 +378,8 @@ promote_rule(::Type{StackedLabeledIsotropicGMM{N, T, L, K}}, ::Type{StackedLabel
 eltype(::Type{StackedLabeledIsotropicGMM{N, T, L, K}}) where {N, T, L, K} = StackedLabeledGaussian{N, T, L, K}
 
 (gmm::StackedLabeledIsotropicGMM)(pos::AbstractVector) = sum(g(pos) for g in gmm)
+
+nfeatures(g::StackedLabeledGaussian) = count(!iszero, g.ϕ)
 
 weights(gmm::AbstractStackedLabeledIsotropicGMM) = [sum(g.ϕ) for g in gmm.gaussians]
 # amplitude-weighted RMS width: reproduces the stack's total second moment Σₖ ϕₖσₖ² in the

--- a/src/gogma/tiv.jl
+++ b/src/gogma/tiv.jl
@@ -221,13 +221,18 @@ end
 # endpoint slot pair's interaction coefficient and amplitude product. This enumerates
 # `2⋅Lx²⋅Ly²` terms per TIV pair — exactly the terms a mean-duplicated model produces, so
 # stacked and duplicated models give identical TIV overlaps, while the distance bounds are
-# evaluated once per TIV pair instead of once per slot pairing. The per-pair term count
-# grows as `L⁴`, so large stacking degrees are expensive.
+# evaluated once per TIV pair instead of once per slot pairing.
 #
-# A zero-amplitude slot is treated as an absent feature: a duplicated model has no TIV
-# ending on it, so every term whose split involves that slot is gated to zero weight — not
-# only the terms whose own amplitude product vanishes. Without the gate, a head term would
-# be counted once per padded tail pairing, with a width computed from the padding σ.
+# A zero-amplitude slot is an absent feature: a duplicated model has no TIV ending on one, so
+# no term whose split involves that slot is emitted at all — not only the terms whose own
+# amplitude product vanishes. Were such a term emitted, a head term would be counted once per
+# padded tail pairing, with a width computed from the padding σ. Iterating only the real slots
+# supplies that exclusion directly.
+#
+# Only terms with a nonzero weight are stored, so the `SVector` length is the largest such
+# count over all pairs rather than `2⋅Lx²⋅Ly²`. Term position carries no meaning — every
+# consumer reads `pσ[i,j][m]` and `pϕ[i,j][m]` together and sums over `m` — but the two must
+# be filled from the same terms, or a weight is silently paired with the wrong variance.
 function tiv_pairwise_consts(
         tivx::StackedTIVGMM{N, T, Lx, K}, tivy::StackedTIVGMM{N, S, Ly, K}, interactions::Dict{Tuple{K, K}, V}
     ) where {N, T, S, Lx, Ly, K, V <: Number}
@@ -242,11 +247,38 @@ function tiv_pairwise_consts(
     hiy = [map(l -> findfirst(isequal(l), uys)::Int, ls) for ls in tivy.headlabels]
     tiy = [map(l -> findfirst(isequal(l), uys)::Int, ls) for ls in tivy.taillabels]
 
-    P = 2 * Lx * Lx * Ly * Ly
-    pσ = Matrix{SVector{P, t}}(undef, length(tivx), length(tivy))
-    pϕ = Matrix{SVector{P, t}}(undef, length(tivx), length(tivy))
-    sbuf = MVector{P, t}(undef)
-    wbuf = MVector{P, t}(undef)
+    rxh = [findall(!iszero, ϕ) for ϕ in tivx.headϕ]
+    rxt = [findall(!iszero, ϕ) for ϕ in tivx.tailϕ]
+    ryh = [findall(!iszero, ϕ) for ϕ in tivy.headϕ]
+    ryt = [findall(!iszero, ϕ) for ϕ in tivy.tailϕ]
+
+    # Each head term is emitted once per real tail pairing and each tail term once per real
+    # head pairing, so the stored count follows from two `O(L²)` tallies rather than an
+    # `O(L⁴)` enumeration.
+    Q = 0
+    for i in eachindex(tivx.gaussians)
+        xhϕ, xtϕ, chx, ctx = tivx.headϕ[i], tivx.tailϕ[i], hix[i], tix[i]
+        for j in eachindex(tivy.gaussians)
+            yhϕ, ytϕ, chy, cty = tivy.headϕ[j], tivy.tailϕ[j], hiy[j], tiy[j]
+            nh = 0
+            for a in rxh[i], c in ryh[j]
+                iszero(coefs[chx[a], chy[c]] * xhϕ[a] * yhϕ[c]) || (nh += 1)
+            end
+            nt = 0
+            for b in rxt[i], d in ryt[j]
+                iszero(coefs[ctx[b], cty[d]] * xtϕ[b] * ytϕ[d]) || (nt += 1)
+            end
+            Q = max(Q, nh * length(rxt[i]) * length(ryt[j]) + nt * length(rxh[i]) * length(ryh[j]))
+        end
+    end
+    return stacked_tiv_consts(Val(Q), tivx, tivy, coefs, hix, tix, hiy, tiy, rxh, rxt, ryh, ryt, t)
+end
+
+function stacked_tiv_consts(::Val{Q}, tivx, tivy, coefs, hix, tix, hiy, tiy, rxh, rxt, ryh, ryt, ::Type{t}) where {Q, t}
+    pσ = Matrix{SVector{Q, t}}(undef, length(tivx), length(tivy))
+    pϕ = Matrix{SVector{Q, t}}(undef, length(tivx), length(tivy))
+    sbuf = MVector{Q, t}(undef)
+    wbuf = MVector{Q, t}(undef)
     for i in eachindex(tivx.gaussians)
         xhσ, xtσ, xhϕ, xtϕ = tivx.headσ[i], tivx.tailσ[i], tivx.headϕ[i], tivx.tailϕ[i]
         chx, ctx = hix[i], tix[i]
@@ -254,20 +286,30 @@ function tiv_pairwise_consts(
             yhσ, ytσ, yhϕ, ytϕ = tivy.headσ[j], tivy.tailσ[j], tivy.headϕ[j], tivy.tailϕ[j]
             chy, cty = hiy[j], tiy[j]
             m = 0
-            for a in 1:Lx, c in 1:Ly
+            for a in rxh[i], c in ryh[j]
                 s_h = xhσ[a]^2 + yhσ[c]^2
                 w_h = coefs[chx[a], chy[c]] * xhϕ[a] * yhϕ[c]
-                head_present = !(iszero(xhϕ[a]) || iszero(yhϕ[c]))
-                for b in 1:Lx, d in 1:Ly
+                for b in rxt[i], d in ryt[j]
                     s_t = xtσ[b]^2 + ytσ[d]^2
                     s_sum = s_h + s_t
-                    tail_present = !(iszero(xtϕ[b]) || iszero(ytϕ[d]))
-                    sbuf[m + 1] = s_sum^2 / s_h
-                    sbuf[m + 2] = s_sum^2 / s_t
-                    wbuf[m + 1] = tail_present ? w_h : zero(t)
-                    wbuf[m + 2] = head_present ? coefs[ctx[b], cty[d]] * xtϕ[b] * ytϕ[d] : zero(t)
-                    m += 2
+                    w_t = coefs[ctx[b], cty[d]] * xtϕ[b] * ytϕ[d]
+                    if !iszero(w_h)
+                        m += 1
+                        sbuf[m] = s_sum^2 / s_h
+                        wbuf[m] = w_h
+                    end
+                    if !iszero(w_t)
+                        m += 1
+                        sbuf[m] = s_sum^2 / s_t
+                        wbuf[m] = w_t
+                    end
                 end
+            end
+            # unused slots must carry a positive variance: they are never read, but a zero
+            # would divide by zero if one ever were
+            for k in (m + 1):Q
+                sbuf[k] = one(t)
+                wbuf[k] = zero(t)
             end
             pσ[i, j] = SVector(sbuf)
             pϕ[i, j] = SVector(wbuf)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1467,6 +1467,21 @@ end
     @test GMA.weights(allpad) == [0.0]
     @test GMA.widths(allpad) == [0.0]
 
+    # nfeatures counts amplitude-nonzero slots, so it is `length` for unstacked models but
+    # not for stacked ones, and it agrees across the two representations of one model
+    @test GMA.nfeatures(g) == 2 && GMA.nfeatures(g2) == 1
+    @test GMA.nfeatures(gmm) == 3 != length(gmm)
+    @test GMA.nfeatures(allpad) == 0
+    @test GMA.nfeatures(gmm) == length(LabeledIsotropicGMM(gmm))
+    @test GMA.nfeatures(StackedLabeledIsotropicGMM{3, Float64, 2, Symbol}()) == 0
+    plain = IsotropicGMM([IsotropicGaussian([0.0, 0.0, 0.0], 0.5, 1.0)])
+    @test GMA.nfeatures(IsotropicGaussian([0.0, 0.0, 0.0], 0.5, 1.0)) == 1
+    @test GMA.nfeatures(plain) == length(plain) == 1
+    @test GMA.nfeatures(IsotropicMultiGMM(Dict(:a => plain, :b => plain))) == 2
+    # a zero-valued amplitude carrying a derivative is a feature, not padding
+    @test GMA.nfeatures(StackedLabeledGaussian([0.0, 0.0, 0.0], [1.0, 1.0],
+        [1.0, ForwardDiff.Dual(0.0, 1.0)], [:a, :b])) == 2
+
     # per-point construction with automatic padding
     padded = StackedLabeledIsotropicGMM(
         [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
@@ -1491,6 +1506,20 @@ end
     @test length(grouped) == 1
     @test grouped.gaussians[1].σ == SVector(0.5, 0.8)
     @test grouped.gaussians[1].labels == SVector(:a, :b)
+
+    # unstacking recovers the mean-duplicated model, inverting both stacking constructors
+    unstacked = LabeledIsotropicGMM(grouped)
+    @test unstacked isa LabeledIsotropicGMM{3, Float64, Symbol}
+    @test unstacked.gaussians == labgmm.gaussians && unstacked.labels == labgmm.labels
+    @test LabeledIsotropicGMM(lifted_gmm).gaussians == labgmm.gaussians
+    @test stackedgmm(unstacked).gaussians == grouped.gaussians
+    # padding is dropped rather than emitted as a zero-amplitude Gaussian
+    @test LabeledIsotropicGMM(padded).labels == [:a, :b, :c]
+    @test isempty(LabeledIsotropicGMM(allpad))
+    @test isempty(LabeledIsotropicGMM(StackedLabeledIsotropicGMM{3, Float64, 2, Symbol}()))
+    # the round trip leaves overlap untouched, padding and all
+    @test overlap(padded, padded) ≈ overlap(LabeledIsotropicGMM(padded), LabeledIsotropicGMM(padded))
+    @test overlap(gmm, padded) ≈ overlap(LabeledIsotropicGMM(gmm), LabeledIsotropicGMM(padded))
 end
 
 @testset "stacked transformations" begin
@@ -1546,19 +1575,22 @@ end
     @test overlap(stk_x, stk_y; interactions) ≈ overlap(lab_x, lab_y; interactions) rtol = 1e-12
     @test overlap(stk_x, stk_y) ≈ overlap(lab_x, lab_y) rtol = 1e-12
 
-    # pairwise constants: one SVector{Lx*Ly} entry per mean pair, zero weight for padded
-    # and non-interacting slot pairs
+    # pairwise constants: one entry per mean pair, holding only the slot pairings whose
+    # weight is nonzero. Term position carries no meaning, so these assert content, not
+    # layout — the two vectors need only stay aligned with each other.
     pσ, pϕ = GMA.pairwise_consts(stk_x, stk_y, interactions)
-    @test pσ isa Matrix{SVector{9, Float64}} && pϕ isa Matrix{SVector{9, Float64}}
+    @test pσ isa Matrix{<:SVector{<:Any, Float64}} && pϕ isa Matrix{<:SVector{<:Any, Float64}}
+    @test length(eltype(pσ)) == length(eltype(pϕ)) == maximum(count.(!iszero, pϕ)) <= 9
     @test size(pσ) == (3, 3)
-    # point 3 has one feature (:b): against point 3 only the (1, 1) slot pair can interact
+    @test all(all(>(0), v) for v in pσ)   # padded slots keep a positive, never-read variance
+    # point 3 has one feature (:b): against point 3 only one slot pairing can interact
     @test count(!iszero, pϕ[3, 3]) == 1
-    @test pϕ[3, 3][1] ≈ 0.5 * 1.2 * 1.2
-    @test pσ[3, 3][1] ≈ 1.0^2 + 1.0^2
+    stored(i, j) = [(pσ[i, j][m], pϕ[i, j][m]) for m in eachindex(pϕ[i, j]) if !iszero(pϕ[i, j][m])]
+    @test only(stored(3, 3))[1] ≈ 1.0^2 + 1.0^2
+    @test only(stored(3, 3))[2] ≈ 0.5 * 1.2 * 1.2
     # slot-pair weights carry the interaction coefficients: (:a, :c) → -0.3
     g1, g1y = stk_x.gaussians[1], stk_y.gaussians[2]
-    m_ac = findfirst(m -> (fldmod1(m, 3) == (1, 2)), 1:9)  # slot 1 (:a) of x vs slot 2 (:c) of y
-    @test pϕ[1, 2][m_ac] ≈ -0.3 * g1.ϕ[1] * g1y.ϕ[2]
+    @test any(c -> c[1] ≈ g1.σ[1]^2 + g1y.σ[2]^2 && c[2] ≈ -0.3 * g1.ϕ[1] * g1y.ϕ[2], stored(1, 2))
 
     # the mean-pair distance bounds are shared, so bounds match the duplicated model exactly
     plσ, plϕ = GMA.pairwise_consts(lab_x, lab_y, interactions)
@@ -1648,7 +1680,13 @@ end
 
     dpσ, dpϕ = GMA.tiv_pairwise_consts(tivd_x, tivd_y, interactions)
     spσ, spϕ = GMA.tiv_pairwise_consts(tivs_x, tivs_y, interactions)
-    @test spσ isa Matrix{SVector{162, Float64}}  # 2 ⋅ 3² ⋅ 3² terms per TIV pair
+    # only nonzero-weight terms are stored, so the length is the largest per-pair count
+    # rather than the dense 2 ⋅ 3² ⋅ 3² = 162
+    @test spσ isa Matrix{<:SVector{<:Any, Float64}}
+    @test length(eltype(spσ)) == maximum(count.(!iszero, spϕ)) < 162
+    @test size(spσ) == size(spϕ) && length(eltype(spσ)) == length(eltype(spϕ))
+    # an unused slot carries zero weight and a positive variance (never read, never singular)
+    @test all(all(>(0), v) for v in spσ)
     for R in (RotationVec(0.0, 0.0, 0.0), RotationVec(0.3, -0.2, 0.5), RotationVec(-1.0, 0.4, 0.9))
         @test overlap(R * tivs_x, tivs_y, spσ, spϕ) ≈ overlap(R * tivd_x, tivd_y, dpσ, dpϕ) rtol = 1e-10
     end
@@ -1662,6 +1700,39 @@ end
     res_lab = tiv_gogma_align(lab_x, lab_y; interactions, maxsplits = 2e3)
     @test res_stk.upperbound ≈ res_lab.upperbound rtol = 1e-6
     @test res_stk.upperbound ≈ -overlap(stk_x, stk_x; interactions) rtol = 1e-4
+
+    # TIV alignment against a known rigid transform of the model recovers that transform.
+    # Only valid when self-alignment is optimal, which needs non-repulsive interactions:
+    # under a net-repulsive dict the models score best pushed apart, not superimposed.
+    attractive = Dict((:a, :a) => 1.0, (:b, :b) => 0.5, (:c, :c) => 0.25)
+    R0, T0 = RotationVec(0.5, -0.3, 0.8), SVector(2.0, -1.5, 3.0)
+    stk_moved = stackedgmm(AffineMap(RotationVec(R0), T0)(lab_x))
+    res = tiv_gogma_align(stk_x, stk_moved; interactions = attractive, maxsplits = 2e4)
+    recovered = GMA.tform(res)
+    @test recovered.linear ≈ RotationVec(R0) atol = 1e-5
+    @test recovered.translation ≈ T0 atol = 1e-5
+    @test overlap(recovered(stk_x), stk_moved; interactions = attractive) ≈
+        overlap(stk_x, stk_x; interactions = attractive) rtol = 1e-6
+
+    # compaction tracks how many weights actually vanish: a sparser interaction dict stores
+    # strictly fewer terms per pair. Even the dense dict stores fewer than the 2 ⋅ 3² ⋅ 3²
+    # slot pairings, because padded slots are excluded whatever the interactions are — these
+    # stacks are ragged (3, 2, and 1 features), so no TIV pair has four full endpoints.
+    sparse_ints = Dict((:a, :a) => 1.0)
+    dense_ints = Dict((p, q) => 1.0 for (i, p) in enumerate([:a, :b, :c]) for q in [:a, :b, :c][i:end])
+    nterms(ints) = length(eltype(GMA.tiv_pairwise_consts(tivs_x, tivs_y, ints)[2]))
+    @test nterms(sparse_ints) < nterms(interactions) < nterms(dense_ints) < 162
+
+    # with full stacks and every label pair interacting, nothing vanishes and compaction is
+    # a no-op: all 2 ⋅ Lx² ⋅ Ly² pairings are stored
+    full = StackedLabeledIsotropicGMM(
+        [SVector(0.0, 0.0, 0.0), SVector(2.0, 0.0, 0.0), SVector(0.0, 2.0, 0.0)],
+        [[0.5, 0.8], [0.6, 0.9], [0.7, 1.0]], [[1.0, 2.0], [1.5, 0.7], [1.2, 1.1]],
+        [[:a, :b], [:a, :b], [:b, :a]]
+    )
+    tiv_full = GMA.tivgmm(full, Inf)
+    all_pairs = Dict((:a, :a) => 1.0, (:b, :b) => 1.0, (:a, :b) => 1.0)
+    @test length(eltype(GMA.tiv_pairwise_consts(tiv_full, tiv_full, all_pairs)[2])) == 2 * 2^2 * 2^2
 
     # mixed stacked × labeled TIV alignment lifts the labeled side
     res_mixed = tiv_gogma_align(stk_x, lab_y; interactions, maxsplits = 1e3)


### PR DESCRIPTION
This is aimed at improving the performance of TIV alignment optimization when using stacked, labeled GMMs.

`pairwise_consts` and `tiv_pairwise_consts` enumerated every slot pairing of a stacked pair, including those a padded slot or a non-interacting label pair gives zero weight. Every consumer skips zero weights, so those entries only lengthened the scan and the allocation.

Both now store the nonzero-weight terms alone, sized to the largest count over all pairs.

Overlaps, bounds, and forces are unchanged: term position carries no meaning, since every consumer reads a variance and a weight together and sums over them. The two vectors must be filled from the same terms, or a weight pairs with the wrong variance; the tests pin that with a term-multiset comparison.

Also adds `nfeatures`, counting amplitude-nonzero slots, and `LabeledIsotropicGMM(::AbstractStackedLabeledIsotropicGMM)`, which unstacks a model into the mean-duplicated one it represents. Both give a stacked model and its duplicated equivalent a common measure where `length` differs.